### PR TITLE
Add toggle to hide compact side slots on notch Macs (fix #2)

### DIFF
--- a/SuperIsland/App/AppState.swift
+++ b/SuperIsland/App/AppState.swift
@@ -273,6 +273,7 @@ final class AppState: ObservableObject {
     @AppStorage("general.expandedAutoDismissDelay") var expandedAutoDismissDelay: Double = 1.0
     @AppStorage("general.notchHapticIntensity") var notchHapticIntensity = NotchHapticIntensity.medium.rawValue
     @AppStorage("general.lockFullExpandedInPlace") var lockFullExpandedInPlace = false
+    @AppStorage("general.hideSideSlots") var hideSideSlots = false
     @AppStorage("onboarding.completed") var onboardingCompleted = false
     @AppStorage("debug.alwaysShowOnboarding") var debugAlwaysShowOnboarding = false
 
@@ -795,6 +796,7 @@ final class AppState: ObservableObject {
 
     var shouldUseMinimalCompactLayout: Bool {
         guard presentationHasNotch,
+              !hideSideSlots,
               compactMinimalSideExpansion > 0,
               let module = compactPresentationModule else {
             return false

--- a/SuperIsland/Settings/GeneralSettingsView.swift
+++ b/SuperIsland/Settings/GeneralSettingsView.swift
@@ -119,6 +119,10 @@ struct GeneralSettingsView: View {
             SettingSectionLabel(title: "Display")
             SettingGroup {
                 SettingToggleRow(title: "Show on all Spaces", isOn: $appState.showOnAllSpaces)
+                if appState.presentationHasNotch {
+                    SettingRowDivider()
+                    SettingToggleRow(title: "Hide side slots", isOn: $appState.hideSideSlots)
+                }
                 SettingRowDivider()
                 HStack {
                     Text("Animation Speed").font(.system(size: 13))

--- a/SuperIsland/Window/IslandWindowController.swift
+++ b/SuperIsland/Window/IslandWindowController.swift
@@ -251,6 +251,9 @@ final class IslandWindowController {
             Task { @MainActor [weak self] in
                 guard let self else { return }
                 self.panel?.setVisibleInScreenRecordings(self.appState.showInScreenRecordings)
+                // Keep the compact frame in sync with settings that change its
+                // content size (e.g. toggling "Hide side slots" on notch Macs).
+                self.updateCompactFrameIfNeeded()
             }
         }
     }


### PR DESCRIPTION
## Summary

Closes shobhit99/superisland#2 — adds a toggle to hide the compact side slots on notch Macs.

### Background

On Macs with a notch, compatible modules (Now Playing and extensions that support `minimalCompactPrecedence`) can extend out of the compact island into slots to the left and right of the notch via `MinimalCompactLayout`. The issue asks for a way to turn these off while keeping the app running.

### Changes

- **`AppState.swift`**
  - New `@AppStorage("general.hideSideSlots") var hideSideSlots = false`.
  - `shouldUseMinimalCompactLayout` now early-returns `false` when `hideSideSlots` is on, so `CompactView` falls through to `standardCompactContent` and `contentSize(for: .compact)` returns the notch-only size.
- **`GeneralSettingsView.swift`**
  - New `SettingToggleRow(title: "Hide side slots", ...)` inside the Display section, gated on `appState.presentationHasNotch` so it only appears on notch Macs (matching the scope requested in the issue).
- **`IslandWindowController.swift`**
  - `observeSettingsChanges()` now also calls `updateCompactFrameIfNeeded()` so the panel frame snaps to the new compact size immediately when the toggle is flipped — same pattern used for the screen-recording toggle next to it.

Non-notch Macs use `WideCompactLayout`, which is unaffected by `shouldUseMinimalCompactLayout`, so the setting is correctly no-op there and the UI hides it.

## Test plan

- [ ] On a notch Mac, start playing music — confirm the album art and playback controls render in the left/right slots flanking the notch by default.
- [ ] Open Settings > General > Display and toggle "Hide side slots" on — confirm the slots disappear immediately and the compact pill snaps back to a notch-sized surface without restart.
- [ ] Toggle it back off — confirm the slots reappear immediately.
- [ ] On a non-notch Mac, confirm the toggle is not visible in Settings and the usual `WideCompactLayout` is unchanged.
- [ ] With slots hidden, expanding the island still works and all modules render correctly in the expanded/full-expanded states.
- [ ] With slots hidden, hovering over the compact notch still triggers hover/expand behavior (the hover mask falls back to the full compact surface in this mode).
