### PR TITLE
Hide notification bell when Notifications module is disabled (fix #12)

### DIFF
--- a/SuperIsland/Views/FullExpandedView.swift
+++ b/SuperIsland/Views/FullExpandedView.swift
@@ -55,8 +55,23 @@ struct FullExpandedView: View {
         }
     }
 
-    private var contentHorizontalPadding: CGFloat {
+    /// The tab actually being rendered — falls back to `.home` when the
+    /// selected tab points to a module that can't currently be presented
+    /// (e.g. a disabled Notifications module). This keeps the Home view's
+    /// padding stable when the fallback to `HomeScreenView()` kicks in.
+    private var effectiveSelectedTab: FullExpandedTab {
         switch appState.fullExpandedSelectedTab {
+        case .home:
+            return .home
+        case .module(let module):
+            return appState.canPresentFullExpandedModule(module)
+                ? .module(module)
+                : .home
+        }
+    }
+
+    private var contentHorizontalPadding: CGFloat {
+        switch effectiveSelectedTab {
         case .home:
             return 0
         case .module(.extension_):
@@ -69,7 +84,7 @@ struct FullExpandedView: View {
     }
 
     private var contentBottomPadding: CGFloat {
-        switch appState.fullExpandedSelectedTab {
+        switch effectiveSelectedTab {
         case .home:
             return 0
         case .module(.extension_):
@@ -297,7 +312,9 @@ struct FullExpandedTopBarView: View {
         HStack(spacing: 8) {
             lockButton
             batteryButton
-            notificationButton
+            if appState.notificationsEnabled {
+                notificationButton
+            }
             settingsButton
         }
         .padding(.leading, settingsLeadingInset)


### PR DESCRIPTION
## Summary

Closes shobhit99/superisland#12 — two linked bugs around the Notifications module toggle.

### Bugs

1. **Bell icon not hidden.** Disabling the Notifications module in Settings kept the bell icon (and its count badge) in the full-expanded top bar, because `FullExpandedTopBarView.trailingShoulderControls` rendered `notificationButton` unconditionally.
2. **Home view width shift on click.** Clicking the bell while the module was disabled selected `.module(.builtIn(.notifications))`. `FullExpandedView.currentTabContent` correctly fell back to `HomeScreenView()` (since `canPresentFullExpandedModule` is false for a disabled module), but `contentHorizontalPadding` / `contentBottomPadding` were still keyed off `fullExpandedSelectedTab`, so they jumped from the `.home` values (0/0) to the notification values (8/4) — shifting the Home view's width and bottom inset.

### Fix

- `FullExpandedTopBarView.trailingShoulderControls`: render `notificationButton` only when `appState.notificationsEnabled` is true, so the icon and its count badge vanish immediately when the module is disabled.
- `FullExpandedView`: introduced `effectiveSelectedTab`, which returns `.home` whenever the selected tab points to a module that can't currently be presented. Both padding helpers now read from this, so the Home fallback always renders with stable padding — even the edge case where the user was already on the notifications tab when they disabled the module.

## Test plan

- [ ] With Notifications module enabled, open the island's full-expanded view and confirm the bell icon is visible in the top bar with the correct count badge.
- [ ] Open Settings and disable the Notifications module — confirm the bell icon (and count badge) disappears immediately from the top bar.
- [ ] Re-enable Notifications — confirm the bell reappears and still shows the live count.
- [ ] Select the notifications tab (via hover-expansion on a notification), then open Settings and disable the Notifications module — confirm the Home view is shown and its width/padding does not shift.
- [ ] Toggling other modules (battery, weather, etc.) still behaves unchanged.
