### PR TITLE
Disable compact-state shadow so clicks pass through (fix #1)

### DIFF
--- a/SuperIsland/Views/IslandContainerView.swift
+++ b/SuperIsland/Views/IslandContainerView.swift
@@ -152,28 +152,33 @@ struct IslandContainerView: View {
         appState.currentState == .compact ? appState.idleOpacity : 1.0
     }
 
+    // Shadows are intentionally disabled in the compact state. The island
+    // panel is non-activating and sits in the transparent region around the
+    // notch — any non-zero shadow pixel in that transparent region gets
+    // captured by the panel's hit test and blocks clicks from reaching apps
+    // underneath (see issue #1).
     private var ambientShadowOpacity: Double {
-        appState.currentState == .compact ? 0.18 : 0.38
+        appState.currentState == .compact ? 0.0 : 0.38
     }
 
     private var ambientShadowRadius: CGFloat {
-        appState.currentState == .compact ? 3 : 8
+        appState.currentState == .compact ? 0 : 8
     }
 
     private var ambientShadowYOffset: CGFloat {
-        appState.currentState == .compact ? 2 : 6
+        appState.currentState == .compact ? 0 : 6
     }
 
     private var keyShadowOpacity: Double {
-        appState.currentState == .compact ? 0.32 : 0.58
+        appState.currentState == .compact ? 0.0 : 0.58
     }
 
     private var keyShadowRadius: CGFloat {
-        appState.currentState == .compact ? 5 : 14
+        appState.currentState == .compact ? 0 : 14
     }
 
     private var keyShadowYOffset: CGFloat {
-        appState.currentState == .compact ? 4 : 10
+        appState.currentState == .compact ? 0 : 10
     }
 
     // MARK: - Expanded Layout


### PR DESCRIPTION
## Summary

Closes shobhit99/superisland#1 — clicks below the compact island were getting swallowed by the panel because the shadow extended into the transparent region beneath the pill.

### Root cause

In the compact state the panel frame is `islandSize.height + 20` (`AppState.windowSize(for: .compact)` at SuperIsland/App/AppState.swift:887). That leaves a ~20pt strip below the visible pill that should be click-through. SwiftUI's `.shadow()` modifier, however, rasterizes shadow pixels into that strip. Since the `IslandPanel` is a non-activating transparent panel, the OS hit-tests against non-zero alpha pixels — so the shadow caused the panel to capture clicks in that strip, blocking them from reaching the underlying app.

### Fix

Zero out both ambient and key shadow parameters when `currentState == .compact` in `SuperIsland/Views/IslandContainerView.swift`:
- `ambientShadowOpacity` / `ambientShadowRadius` / `ambientShadowYOffset`
- `keyShadowOpacity` / `keyShadowRadius` / `keyShadowYOffset`

The expanded and full-expanded states keep their existing shadows untouched — in those states the solid pill already fills the clickable window area, so shadow pixels don't sit over transparent space.

## Test plan

- [ ] With the island in compact state, open a window underneath the notch area (e.g. a browser with a button near the top edge) and confirm clicks on the area just below/around the pill reach the underlying app instead of being captured.
- [ ] Hover / click the compact pill itself — confirm it still expands as before.
- [ ] Trigger the compact → expanded → full-expanded transitions and confirm the expanded shadow still renders normally.
- [ ] Drop a file onto the island and confirm the shelf drop target overlay still works in expanded state.
- [ ] No visual regression on the compact pill itself (the pill shape and fill are untouched, only the cast shadow is removed).
