### PR TITLE
Skip Spotify AppleScript when Spotify isn't installed (fix #8)

### DIFF
--- a/SuperIsland/Modules/NowPlaying/NowPlayingManager.swift
+++ b/SuperIsland/Modules/NowPlaying/NowPlayingManager.swift
@@ -507,6 +507,11 @@ final class NowPlayingManager: ObservableObject {
     }
 
     nonisolated private func fetchSpotifyViaAppleScript() -> Bool {
+        // Don't compile any `tell application "Spotify"` AppleScript when
+        // Spotify isn't installed — doing so causes macOS to pop the
+        // "Where is Spotify?" Finder picker on every launch (issue #8).
+        guard isSpotifyInstalled() else { return false }
+
         let script = """
         tell application "System Events"
             if not (exists process "Spotify") then return "NOT_RUNNING"
@@ -552,6 +557,8 @@ final class NowPlayingManager: ObservableObject {
     }
 
     nonisolated private func fetchSpotifyArtwork() {
+        guard isSpotifyInstalled() else { return }
+
         let script = """
         tell application "Spotify"
             return artwork url of current track
@@ -1089,6 +1096,10 @@ final class NowPlayingManager: ObservableObject {
         value
             .replacingOccurrences(of: "\\", with: "\\\\")
             .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+
+    nonisolated private func isSpotifyInstalled() -> Bool {
+        NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.spotify.client") != nil
     }
 
     private func isApplicationRunning(_ name: String) -> Bool {


### PR DESCRIPTION
## Summary

Closes shobhit99/superisland#8 — the "Where is Spotify?" Finder picker no longer appears on app start when Spotify isn't installed.

### Root cause

`NowPlayingManager.fetchSpotifyViaAppleScript` is called from `refreshPreferredSource` shortly after launch (see `SuperIsland/Modules/NowPlaying/NowPlayingManager.swift:82`) as part of normal source-detection polling. The script is structured like this:

```applescript
tell application "System Events"
    if not (exists process "Spotify") then return "NOT_RUNNING"
end tell
tell application "Spotify"
    if player state is playing then
        ...
```

The first block runs via `System Events` and intends to bail out when Spotify isn't running. But AppleScript still resolves the second `tell application "Spotify"` block by bundle identifier at compile time — before any of the runtime `exists process` check fires. When Spotify.app isn't installed, macOS can't find the bundle and pops up the "Where is Spotify?" Finder picker.

### Fix

- New `nonisolated private func isSpotifyInstalled() -> Bool` that calls `NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.spotify.client")`.
- Early `guard isSpotifyInstalled() else { return false }` at the top of `fetchSpotifyViaAppleScript`.
- Same guard in `fetchSpotifyArtwork` (which runs `tell application "Spotify" to return artwork url ...`).

When Spotify isn't installed we never hand the AppleScript to macOS, so no Finder picker appears.

The playback-control AppleScripts (play / pause / next / previous / seek) don't need the same guard — they are only reached once `sourceName` has already been set to `"Spotify"`, which requires MediaRemote (or a successful `fetchSpotifyViaAppleScript`) to have reported Spotify as the active app, so Spotify must already be installed and running. `togglePlayPause` also bails via `isApplicationRunning("Spotify")`.

## Test plan

- [ ] On a Mac **without** Spotify installed, launch SuperIsland cold — confirm the "Where is Spotify?" Finder picker no longer appears (the bug reproduction).
- [ ] Confirm Now Playing still picks up music from Apple Music, Chrome, YouTube, etc. via the existing AppleScript and MediaRemote paths.
- [ ] On a Mac **with** Spotify installed and playing, launch SuperIsland — confirm Spotify info (title, artist, album art) still appears in the compact and expanded views as before.
- [ ] With Spotify installed, use play/pause/next/previous/seek controls — confirm they still work.
- [ ] Install Spotify after SuperIsland is already running — note that a restart is required for the new install to be picked up (acceptable trade-off; the lookup is cached implicitly per-process).
