### PR TITLE
Add temperature unit conversion to weather display

### DIFF
--- a/SuperIsland/Views/HomeScreenView.swift
+++ b/SuperIsland/Views/HomeScreenView.swift
@@ -241,6 +241,16 @@ private struct HomeCalendarPanel: View {
 
 private struct HomeWeatherPanel: View {
     @ObservedObject private var manager = WeatherManager.shared
+    @ObservedObject private var appState = AppState.shared
+
+    private func formattedTemp(_ celsius: Double) -> String {
+        switch appState.temperatureUnit {
+        case .celsius:
+            return "\(Int(celsius.rounded()))°"
+        case .fahrenheit:
+            return "\(Int((celsius * 9 / 5 + 32).rounded()))°"
+        }
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -263,7 +273,7 @@ private struct HomeWeatherPanel: View {
                             )
 
                         VStack(alignment: .leading, spacing: 1) {
-                            Text("\(Int(manager.weather.temperature))°")
+                            Text(formattedTemp(manager.weather.temperature))
                                 .font(HomeTypography.temperatureFont)
                                 .foregroundStyle(HomeTypography.primaryText)
 
@@ -284,13 +294,13 @@ private struct HomeWeatherPanel: View {
                     HStack(spacing: 8) {
                         weatherStat(
                             title: "High",
-                            value: "\(Int(manager.weather.temperatureHigh))°",
+                            value: formattedTemp(manager.weather.temperatureHigh),
                             icon: "arrow.up.circle.fill",
                             tint: Color.orange.opacity(0.88)
                         )
                         weatherStat(
                             title: "Low",
-                            value: "\(Int(manager.weather.temperatureLow))°",
+                            value: formattedTemp(manager.weather.temperatureLow),
                             icon: "arrow.down.circle.fill",
                             tint: Color.cyan.opacity(0.88)
                         )


### PR DESCRIPTION
## Summary
Added support for displaying temperatures in both Celsius and Fahrenheit units in the HomeWeatherPanel, respecting the user's temperature unit preference from AppState.

## Key Changes
- Added `AppState` observation to `HomeWeatherPanel` to access the user's temperature unit preference
- Created `formattedTemp(_:)` helper method that converts Celsius temperatures to the selected unit (Celsius or Fahrenheit) and formats them as rounded integers with the degree symbol
- Updated all temperature displays to use the new `formattedTemp()` method:
  - Current temperature
  - High temperature
  - Low temperature

## Implementation Details
- The conversion formula for Fahrenheit is: `(celsius * 9 / 5 + 32)`
- All temperatures are rounded to the nearest integer for cleaner display
- The helper method centralizes temperature formatting logic, making it easy to maintain and update in the future

https://claude.ai/code/session_01EeipTGufvY3jn3DwSDHjy6