### PR TITLE
Add "Hide on fullscreen" option for non-notch Macs (fix #18)

### DIFF
--- a/SuperIsland/App/AppState.swift
+++ b/SuperIsland/App/AppState.swift
@@ -274,6 +274,7 @@ final class AppState: ObservableObject {
     @AppStorage("general.notchHapticIntensity") var notchHapticIntensity = NotchHapticIntensity.medium.rawValue
     @AppStorage("general.lockFullExpandedInPlace") var lockFullExpandedInPlace = false
     @AppStorage("general.hideSideSlots") var hideSideSlots = false
+    @AppStorage("general.hideOnFullscreen") var hideOnFullscreen = false
     @AppStorage("onboarding.completed") var onboardingCompleted = false
     @AppStorage("debug.alwaysShowOnboarding") var debugAlwaysShowOnboarding = false
 

--- a/SuperIsland/Settings/GeneralSettingsView.swift
+++ b/SuperIsland/Settings/GeneralSettingsView.swift
@@ -122,6 +122,9 @@ struct GeneralSettingsView: View {
                 if appState.presentationHasNotch {
                     SettingRowDivider()
                     SettingToggleRow(title: "Hide side slots", isOn: $appState.hideSideSlots)
+                } else {
+                    SettingRowDivider()
+                    SettingToggleRow(title: "Hide on fullscreen", isOn: $appState.hideOnFullscreen)
                 }
                 SettingRowDivider()
                 HStack {

--- a/SuperIsland/Window/IslandWindowController.swift
+++ b/SuperIsland/Window/IslandWindowController.swift
@@ -25,8 +25,11 @@ final class IslandWindowController {
     private let appState = AppState.shared
     private var screenObserver: Any?
     private var defaultsObserver: Any?
+    private var activeSpaceObserver: Any?
+    private var fullscreenPollTimer: Timer?
     private var cancellables = Set<AnyCancellable>()
     private var shrinkWorkItem: DispatchWorkItem?
+    private var isHiddenForFullscreen = false
 
     func showIsland() {
         let panel = IslandPanel()
@@ -68,6 +71,8 @@ final class IslandWindowController {
         observeSettingsChanges()
         observeStateChanges()
         observeCompactLayoutChanges()
+        observeFullscreenChanges()
+        updateFullscreenVisibility()
     }
 
     func hideIsland() {
@@ -254,8 +259,111 @@ final class IslandWindowController {
                 // Keep the compact frame in sync with settings that change its
                 // content size (e.g. toggling "Hide side slots" on notch Macs).
                 self.updateCompactFrameIfNeeded()
+                // Re-evaluate fullscreen visibility when the toggle changes.
+                self.updateFullscreenVisibility()
             }
         }
+    }
+
+    // MARK: - Fullscreen hiding (non-notch Macs)
+    //
+    // On non-notch Macs the island floats over normal app windows, which
+    // is distracting when another app is in true fullscreen (e.g. a video
+    // player). When the user opts in via Settings we hide the panel while
+    // any non-SuperIsland window matches the screen frame exactly, and
+    // restore it as soon as that fullscreen window goes away.
+
+    private func observeFullscreenChanges() {
+        // activeSpaceDidChange fires when the user enters/exits fullscreen
+        // (each fullscreen app gets its own space) or switches spaces.
+        activeSpaceObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.activeSpaceDidChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.updateFullscreenVisibility()
+            }
+        }
+
+        // Low-frequency safety net: some fullscreen transitions (e.g. the
+        // native video player going fullscreen in-place) don't always fire
+        // a space change notification, so re-check every 2s while the
+        // controller is alive. The check is cheap (CGWindowListCopyWindowInfo
+        // with bounds only) and only runs as long as the app is up.
+        fullscreenPollTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.updateFullscreenVisibility()
+            }
+        }
+    }
+
+    private func updateFullscreenVisibility() {
+        guard let panel else { return }
+
+        // The feature is scoped to non-notch Macs per issue #18 — on notch
+        // Macs the island lives in the hardware cutout and doesn't overlap
+        // fullscreen content.
+        let shouldConsider = appState.hideOnFullscreen && !appState.presentationHasNotch
+        guard shouldConsider else {
+            if isHiddenForFullscreen {
+                isHiddenForFullscreen = false
+                panel.orderFrontRegardless()
+            }
+            return
+        }
+
+        let screen = panel.screen
+            ?? ScreenDetector.activeScreen
+            ?? ScreenDetector.primaryScreen
+            ?? NSScreen.screens.first
+        guard let screen else { return }
+
+        let fullscreen = Self.isFullscreenWindowPresent(on: screen)
+
+        if fullscreen && !isHiddenForFullscreen {
+            isHiddenForFullscreen = true
+            panel.orderOut(nil)
+        } else if !fullscreen && isHiddenForFullscreen {
+            isHiddenForFullscreen = false
+            panel.orderFrontRegardless()
+        }
+    }
+
+    /// Returns true when any on-screen window from another process exactly
+    /// covers the given screen's frame — the classic signature of a native
+    /// macOS fullscreen app.
+    private static func isFullscreenWindowPresent(on screen: NSScreen) -> Bool {
+        let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
+        guard let info = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] else {
+            return false
+        }
+
+        let ourPID = Int(ProcessInfo.processInfo.processIdentifier)
+        let screenFrame = screen.frame
+
+        for window in info {
+            // Skip windows owned by SuperIsland itself.
+            if let pid = window[kCGWindowOwnerPID as String] as? Int, pid == ourPID {
+                continue
+            }
+            // Only consider windows in the normal content layer. The menu
+            // bar, Dock, and status items live on non-zero layers.
+            if let layer = window[kCGWindowLayer as String] as? Int, layer != 0 {
+                continue
+            }
+            guard let boundsDict = window[kCGWindowBounds as String] as? [String: Any],
+                  let rect = CGRect(dictionaryRepresentation: boundsDict as CFDictionary) else {
+                continue
+            }
+            // CGWindow bounds use pixel sizes; compare width/height with a
+            // small tolerance to guard against rounding on Retina screens.
+            if abs(rect.width - screenFrame.width) < 1.5
+                && abs(rect.height - screenFrame.height) < 1.5 {
+                return true
+            }
+        }
+        return false
     }
 
     deinit {
@@ -265,6 +373,10 @@ final class IslandWindowController {
         if let observer = defaultsObserver {
             NotificationCenter.default.removeObserver(observer)
         }
+        if let observer = activeSpaceObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(observer)
+        }
+        fullscreenPollTimer?.invalidate()
         cancellables.removeAll()
     }
 }


### PR DESCRIPTION
## Summary

Closes shobhit99/superisland#18 — adds an opt-in "Hide on fullscreen" toggle for non-notch Macs.

### Why non-notch only

On notch Macs the island sits inside the hardware cutout, so it never overlaps app content and this toggle would have nothing to do. On non-notch Macs the island floats above normal windows — including true-fullscreen windows — which is the exact annoyance the issue describes (island covering a fullscreen video). The user explicitly confirmed the feature is non-notch only. The Display section already has a symmetric pattern: "Hide side slots" is shown **only** for notch Macs, so "Hide on fullscreen" slots in nicely in the `else` branch.

### Changes

- **`SuperIsland/App/AppState.swift`** — new `@AppStorage("general.hideOnFullscreen") var hideOnFullscreen = false`.
- **`SuperIsland/Settings/GeneralSettingsView.swift`** — new `SettingToggleRow(title: "Hide on fullscreen", isOn: $appState.hideOnFullscreen)` rendered in the Display section **only** when `!appState.presentationHasNotch` (mirroring the notch-only "Hide side slots" row above it).
- **`SuperIsland/Window/IslandWindowController.swift`** —
  - `observeFullscreenChanges()` adds a `NSWorkspace.activeSpaceDidChangeNotification` observer (fires when entering/exiting fullscreen — each fullscreen app gets its own space) plus a 2s `Timer` safety net for in-place fullscreen transitions that don't always emit a space change.
  - `updateFullscreenVisibility()` is the decision point: no-op unless `hideOnFullscreen && !presentationHasNotch`, then checks the island's current screen and either `orderOut`s or `orderFrontRegardless`s the panel.
  - `isFullscreenWindowPresent(on:)` uses `CGWindowListCopyWindowInfo` with `.optionOnScreenOnly` and `.excludeDesktopElements` and looks for any window whose `kCGWindowOwnerPID` isn't ours, `kCGWindowLayer == 0`, and `kCGWindowBounds` matches the screen's `frame` within 1.5pt. That's the standard signature of a native macOS fullscreen app.
  - `observeSettingsChanges()` now also calls `updateFullscreenVisibility()` so toggling the setting takes effect immediately without restart (same live-update pattern used for "Hide side slots").
  - `isHiddenForFullscreen` tracks current visibility so we only issue one `orderOut` / one `orderFrontRegardless` per transition, and so disabling the setting (or flipping the notch state) un-hides the panel cleanly.
  - `deinit` tears down the workspace observer and the poll timer.

`orderFrontRegardless()` (not `makeKeyAndOrderFront(nil)`) is used on restore so we don't accidentally steal focus back from the previously fullscreen app when the user exits fullscreen into a different foreground window.

## Test plan

- [ ] On a non-notch Mac, open Settings > General > Display — confirm the new "Hide on fullscreen" row appears and "Hide side slots" does **not**. On a notch Mac, confirm the opposite.
- [ ] With the setting **off**, open a YouTube video, hit fullscreen — confirm the island is still visible over the video (previous behavior).
- [ ] Enable "Hide on fullscreen", enter fullscreen on any app (QuickTime / YouTube / Keynote / an app's native `.fullScreen` window) — confirm the island disappears.
- [ ] Exit fullscreen (Esc / green button) — confirm the island reappears.
- [ ] Toggle the setting on while already inside a fullscreen app — confirm the island disappears immediately.
- [ ] Toggle the setting off while the island is hidden for fullscreen — confirm the island reappears immediately.
- [ ] Switch between fullscreen spaces via Mission Control / Ctrl+← / Ctrl+→ — confirm the island shows/hides correctly on each space.
- [ ] Multi-monitor: put a fullscreen window on one display while the island is on the other — confirm the island is only hidden when the fullscreen window is on the same screen as the island (the check uses `panel.screen`).
