### PR TITLE
Disable automatic Claude code review on pull requests

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,14 +1,17 @@
 name: Claude Code Review
 
 on:
-  pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+  # Auto code review on pull requests is disabled.
+  # The workflow can still be triggered manually from the Actions tab.
+  workflow_dispatch:
+  # pull_request:
+  #   types: [opened, synchronize, ready_for_review, reopened]
+  #   # Optional: Only run on specific file changes
+  #   # paths:
+  #   #   - "src/**/*.ts"
+  #   #   - "src/**/*.tsx"
+  #   #   - "src/**/*.js"
+  #   #   - "src/**/*.jsx"
 
 jobs:
   claude-review:


### PR DESCRIPTION
## Summary
Disabled the automatic Claude code review workflow that was triggered on pull request events. The workflow can now only be triggered manually from the GitHub Actions tab.

## Changes
- Replaced the `pull_request` trigger with `workflow_dispatch` to allow manual triggering only
- Commented out the automatic pull request event types (`opened`, `synchronize`, `ready_for_review`, `reopened`)
- Commented out the optional file path filters for TypeScript, TSX, JavaScript, and JSX files

## Rationale
This change prevents the Claude code review from automatically running on every pull request, reducing unnecessary workflow executions while still allowing developers to manually trigger code reviews when needed through the GitHub Actions interface.

https://claude.ai/code/session_01JCE39iUjjMnF8kewZuhEvc