### PR TITLE
Don't give inactive extensions compact/tab precedence (fix #32)

### DIFF
--- a/ExtensionHost/ExtensionJSRuntime.swift
+++ b/ExtensionHost/ExtensionJSRuntime.swift
@@ -161,14 +161,14 @@ final class ExtensionJSRuntime {
         }
 
         if rawValue.isNumber {
-            return max(1, Int(rawValue.toInt32()))
+            return max(0, Int(rawValue.toInt32()))
         }
 
         if rawValue.isObject,
            let result = rawValue.call(withArguments: []),
            !result.isUndefined,
            !result.isNull {
-            return max(1, Int(result.toInt32()))
+            return max(0, Int(result.toInt32()))
         }
 
         return 1

--- a/Extensions/pomodoro/index.js
+++ b/Extensions/pomodoro/index.js
@@ -352,7 +352,7 @@ SuperIsland.registerModule({
       return View.text(formatTime(remainingSeconds), { style: "monospacedSmall", color: "white" });
     },
     precedence: function() {
-      return isRunning ? 1 : 2;
+      return isRunning ? 1 : 0;
     }
   },
 

--- a/SuperIsland/App/AppState.swift
+++ b/SuperIsland/App/AppState.swift
@@ -711,6 +711,15 @@ final class AppState: ObservableObject {
         return module
     }
 
+    /// Returns `true` when an extension reports precedence 0, meaning it
+    /// considers itself inactive (e.g. a paused Pomodoro timer) and should
+    /// not take over the compact view or the default full-expanded tab.
+    func isExtensionInactive(_ module: ActiveModule) -> Bool {
+        guard case .extension_(let extensionID) = module else { return false }
+        let precedence = ExtensionManager.shared.extensionStates[extensionID]?.minimalCompactPrecedence ?? 1
+        return precedence == 0
+    }
+
     private func isCyclableIslandModule(_ module: ModuleType) -> Bool {
         switch module {
         case .volumeHUD, .battery:
@@ -771,6 +780,12 @@ final class AppState: ObservableObject {
             : nil
 
         guard let activeModule else {
+            return mediaModule
+        }
+
+        // Extensions with precedence 0 are inactive — treat them as if
+        // no module is active so the compact view falls back to media or default.
+        if isExtensionInactive(activeModule) {
             return mediaModule
         }
 
@@ -1133,7 +1148,7 @@ final class AppState: ObservableObject {
             nextTab = .module(.builtIn(.shelf))
         } else if prefersHome {
             nextTab = .home
-        } else if let activeModule, supportsFullExpandedModule(activeModule) {
+        } else if let activeModule, !isExtensionInactive(activeModule), supportsFullExpandedModule(activeModule) {
             nextTab = .module(activeModule)
         } else {
             nextTab = .home

--- a/SuperIsland/Views/CompactView.swift
+++ b/SuperIsland/Views/CompactView.swift
@@ -11,7 +11,9 @@ struct CompactView: View {
                let module = appState.compactPresentationModule {
                 minimalCompactContent(for: module)
             } else if appState.usesWideCompactLayout,
-                      case .extension_(let extensionID) = appState.activeModule {
+                      let module = appState.activeModule,
+                      case .extension_(let extensionID) = module,
+                      !appState.isExtensionInactive(module) {
                 WideCompactLayout(
                     leading: AnyView(ExtensionRendererView(extensionID: extensionID, displayMode: .minimalLeading)),
                     trailing: AnyView(ExtensionRendererView(extensionID: extensionID, displayMode: .minimalTrailing))

--- a/SuperIsland/Views/CompactView.swift
+++ b/SuperIsland/Views/CompactView.swift
@@ -41,6 +41,9 @@ struct CompactView: View {
     /// Music overrides only apply when Now Playing is enabled in settings.
     private var resolvedModule: ActiveModule? {
         guard let module = appState.activeModule else { return nil }
+        // Extensions with precedence 0 are inactive — fall through to the
+        // default compact content (now playing or battery).
+        if appState.isExtensionInactive(module) { return nil }
         if case .builtIn(let t) = module, t == .volumeHUD {
             // In compact state the HUD has already dismissed — let music take over.
             if appState.nowPlayingEnabled, nowPlaying.isPlaying, appState.currentState == .compact {


### PR DESCRIPTION
Extensions can now report precedence 0 to signal "I'm not active — don't show me."  The Pomodoro timer returns 0 when its timer is paused or idle.

Host-side changes:
- resolveMinimalCompactPrecedence allows 0 (was clamped to 1).
- New isExtensionInactive() helper on AppState.
- compactPresentationModule falls back to media/default when the active extension has precedence 0.
- resolvedModule in CompactView returns nil for inactive extensions, so the pill shows Now Playing or Battery instead.
- prepareFullExpandedPresentation defaults to Home when the active extension is inactive.