### PR TITLE
fix(agents-status): focus correct iTerm2 tab on session click

### DIFF
--- a/Extensions/agents-status/server/server.py
+++ b/Extensions/agents-status/server/server.py
@@ -2162,6 +2162,37 @@ end run
     return _run_osascript(script, [tty], timeout=5.0)
 
 
+def _focus_iterm_session(session):
+    tty = _tty_for_pid(session.get("pid"))
+    if not tty:
+        return _activate_app("iTerm")
+    script = """on run argv
+  set targetTTY to item 1 of argv
+  tell application "iTerm"
+    activate
+    repeat with w in windows
+      repeat with t in tabs of w
+        repeat with s in sessions of t
+          set sessionTTY to ""
+          try
+            set sessionTTY to tty of s
+          end try
+          if sessionTTY is targetTTY or sessionTTY is ("/dev/" & targetTTY) then
+            tell t to select
+            tell s to select
+            set index of w to 1
+            return "focused"
+          end if
+        end repeat
+      end repeat
+    end repeat
+  end tell
+  error "TTY not found: " & targetTTY
+end run
+"""
+    return _run_osascript(script, [tty], timeout=5.0)
+
+
 def _focus_session_terminal(session):
     terminal = (session.get("terminal") or "").strip()
     if not terminal:
@@ -2176,6 +2207,10 @@ def _focus_session_terminal(session):
         ok, detail = _focus_terminal_app_session(session)
         if ok:
             return True, {"ok": True, "terminal": terminal, "method": "terminal-tty"}
+    elif terminal == "iTerm":
+        ok, detail = _focus_iterm_session(session)
+        if ok:
+            return True, {"ok": True, "terminal": terminal, "method": "iterm-tty"}
 
     app_name = TERMINAL_APP_NAMES.get(terminal) or terminal
     if app_name:


### PR DESCRIPTION
## Summary
- Clicking an agent session in SuperIsland that was running in **iTerm2** activated the app but did not switch to the tab containing the agent — iTerm fell through to a generic `open -a iTerm`. This adds an iTerm-specific TTY-based focus handler, mirroring the existing Terminal.app path.
- Catches the iTerm2 AppleScript quirk where `tell session to select` only changes the active pane within its tab; `tell tab to select` is required to actually switch tabs in the window. Then `set index of window to 1` raises the window.
- Falls back to `_activate_app("iTerm")` if `ps -o tty=` can't recover a tty for the session pid.

## Why
`_focus_session_terminal` already had dedicated handlers for Warp, Ghostty, and Terminal.app. iTerm hit only the generic `_activate_app` branch, so users saw iTerm pop forward but stay on whatever tab was previously front, not the one for the clicked session.

## Test plan
- [x] Local: trigger `POST /focus` on `agents-status` server (port 7823) for an iTerm-hosted Claude session — server returns `{"ok":true,"terminal":"iTerm","method":"iterm-tty"}` and iTerm switches to the matching tab in the front window.
- [x] Verified `tty of session` (`/dev/ttysNNN`) correctly matches `ps -o tty=` output (`ttysNNN`) via the existing `"/dev/" & targetTTY` fallback comparison.
- [x] Confirmed `tell tab to select` step is what actually switches tabs — without it, server reports success but iTerm stays on the previously front tab (the bug being fixed).
- [ ] Reviewer: try with multiple iTerm windows to verify `set index of window to 1` raises the correct window.
- [ ] Reviewer: try iTerm2 split-pane case (multiple sessions in one tab) — `tell session to select` after the tab select should pick the correct pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)