### PR TITLE
Reduce idle energy usage with central module refresh scheduling

### DIFF
--- a/ExtensionHost/ExtensionJSRuntime.swift
+++ b/ExtensionHost/ExtensionJSRuntime.swift
@@ -31,6 +31,7 @@ final class ExtensionJSRuntime {
     private var timers: [Int: Timer] = [:]
     private var nextTimerID: Int = 1
     private var didActivate = false
+    private var timersSuspended = false
 
     private let defaults = UserDefaults.standard
     private var islandActivationModule: ActiveModule {
@@ -110,6 +111,10 @@ final class ExtensionJSRuntime {
 
     func cleanup() {
         deactivate()
+    }
+
+    func setTimersSuspended(_ suspended: Bool) {
+        timersSuspended = suspended
     }
 
     @MainActor
@@ -861,14 +866,21 @@ final class ExtensionJSRuntime {
         let timerID = nextTimerID
         nextTimerID += 1
 
-        let interval = max(0.01, milliseconds / 1000)
+        let requestedInterval = max(0.01, milliseconds / 1000)
+        let interval = repeats ? max(0.25, requestedInterval) : requestedInterval
         let timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: repeats) { [weak self] timer in
             guard let self else { return }
+            if repeats, self.timersSuspended {
+                return
+            }
             self.invokeJS("timer(\(timerID))") { callback.call(withArguments: []) }
             if !repeats {
                 self.timers.removeValue(forKey: timerID)
                 timer.invalidate()
             }
+        }
+        if repeats {
+            timer.tolerance = max(0.05, interval * 0.2)
         }
 
         RunLoop.main.add(timer, forMode: .common)

--- a/ExtensionHost/ExtensionManager.swift
+++ b/ExtensionHost/ExtensionManager.swift
@@ -54,7 +54,7 @@ final class ExtensionManager: ObservableObject {
         installed.first(where: { $0.id == extensionID })?.capabilities.notificationFeed == true
     }
 
-    private var refreshTimers: [String: Timer] = [:]
+    private var refreshTokens: [String: ModuleRefreshToken] = [:]
     private var immediateRefreshWorkItems: [String: DispatchWorkItem] = [:]
     private var presentedInteractionContexts: [String: PresentedInteractionContext] = [:]
     private let fileManager = FileManager.default
@@ -244,6 +244,7 @@ final class ExtensionManager: ObservableObject {
             runtime.activate()
 
             startRefreshTimer(for: manifest)
+            syncRuntimeEnergyState()
             refreshState(extensionID: extensionID)
 
             ExtensionLogger.shared.log(extensionID, .info, "Activated extension")
@@ -277,6 +278,13 @@ final class ExtensionManager: ObservableObject {
         guard let runtime = runtimes[extensionID] else { return }
         if let state = runtime.fetchState() {
             extensionStates[extensionID] = state
+        }
+    }
+
+    func syncRuntimeEnergyState() {
+        for manifest in installed {
+            guard let runtime = runtimes[manifest.id] else { continue }
+            runtime.setTimersSuspended(shouldSuspendRuntimeTimers(for: manifest))
         }
     }
 
@@ -433,19 +441,49 @@ final class ExtensionManager: ObservableObject {
             return
         }
 
-        let timer = Timer.scheduledTimer(withTimeInterval: max(0.1, manifest.refreshInterval), repeats: true) { [weak self] _ in
-            Task { @MainActor in
-                self?.refreshState(extensionID: manifest.id)
-            }
-        }
+        let interval = max(2, manifest.refreshInterval)
+        let module = refreshModule(for: manifest)
+        let policy: ModuleRefreshPolicy = manifest.capabilities.notificationFeed
+            ? .interval(interval, tolerance: max(0.5, interval * 0.25))
+            : .visibleOnly(interval, tolerance: max(0.5, interval * 0.25))
 
-        RunLoop.main.add(timer, forMode: .common)
-        refreshTimers[manifest.id] = timer
+        refreshTokens[manifest.id] = ModuleRefreshScheduler.shared.register(
+            id: "extension.\(manifest.id).refresh",
+            name: "\(manifest.name) extension refresh",
+            module: module,
+            policy: policy,
+            enabled: { [weak self] in
+                guard let self else { return false }
+                return self.runtimes[manifest.id] != nil
+                    && manifest.capabilities.backgroundRefresh
+                    && manifest.activationTriggers.contains { $0.caseInsensitiveCompare("timer") == .orderedSame }
+            }
+        ) { [weak self] in
+            self?.refreshState(extensionID: manifest.id)
+        }
     }
 
     private func stopRefreshTimer(for extensionID: String) {
-        refreshTimers[extensionID]?.invalidate()
-        refreshTimers.removeValue(forKey: extensionID)
+        ModuleRefreshScheduler.shared.unregister(refreshTokens[extensionID])
+        refreshTokens.removeValue(forKey: extensionID)
+    }
+
+    private func refreshModule(for manifest: ExtensionManifest) -> ActiveModule {
+        manifest.capabilities.notificationFeed ? .builtIn(.notifications) : .extension_(manifest.id)
+    }
+
+    private func shouldSuspendRuntimeTimers(for manifest: ExtensionManifest) -> Bool {
+        let module = refreshModule(for: manifest)
+        let appState = AppState.shared
+        guard !appState.isModuleVisibleForRefresh(module) else { return false }
+
+        if appState.effectiveEnergyMode == .lowPower || appState.disableBackgroundExtensionRefresh {
+            return true
+        }
+
+        return appState.effectiveEnergyMode == .smart
+            && appState.currentState == .compact
+            && !appState.isHovering
     }
 }
 struct WhatsAppWebMessage: Identifiable {

--- a/Extensions/agents-status/manifest.json
+++ b/Extensions/agents-status/manifest.json
@@ -18,6 +18,6 @@
     "backgroundRefresh": true,
     "settings": true
   },
-  "refreshInterval": 0.5,
+  "refreshInterval": 5.0,
   "activationTriggers": ["manual", "timer"]
 }

--- a/PR_NOTES_PR-01.md
+++ b/PR_NOTES_PR-01.md
@@ -1,0 +1,40 @@
+# PR-01 Notes
+
+Title: Reduce idle energy usage with central module refresh scheduling
+
+Branch: `perf/energy-and-refresh-scheduler`
+
+Linked issues:
+- #67 Energy consumption on MacBook Air is very poor
+- #68 Poor power management
+- #69 Using Significant Energy
+
+Summary:
+- Adds a central refresh scheduler for built-in modules and extensions.
+- Adds Normal, Smart, and Low Power profiles in Settings -> General -> Power.
+- Pauses or slows non-essential refresh while modules are hidden, disabled, collapsed, or inactive.
+- Adds optional Low Power suggestions for battery transitions and sustained refresh activity.
+- Adds scheduler diagnostics in Settings -> Advanced.
+- Adds timer tolerance, lifecycle cleanup, and duplicate state suppression across the highest-frequency managers.
+- Guards extension refresh intervals and suspends inactive extension timers in Smart and Low Power conditions.
+
+Validation:
+- `git diff --check` passed.
+- Direct Swift typecheck of app sources passed with the package-backed analytics source excluded because package resolution depends on generated project setup.
+- `xcodebuild -version` reported Xcode 26.5.
+- `xcodegen generate` could not run because `xcodegen` is unavailable locally.
+- `xcodebuild -project SuperIsland.xcodeproj -scheme SuperIsland -configuration Debug build` could not run because the project file is generated and is not present without XcodeGen.
+
+Screenshots needed:
+- Settings -> General -> Power section.
+- Settings -> Advanced -> Energy Diagnostics section with scheduled jobs visible.
+
+Risk notes:
+- Refresh cadence changes can affect perceived freshness for notifications, extensions, and Now Playing fallback updates.
+- Calendar still has existing Swift concurrency warnings around EventKit values used off the main queue.
+- Weather still has existing macOS 26 deprecation warnings for reverse geocoding APIs.
+- Manual idle-energy verification in Activity Monitor or Instruments is still needed on a real Mac session.
+
+PR status:
+- Branch is prepared locally.
+- PR was not opened locally because the GitHub CLI is unavailable.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ scripts/            Build & release scripts
 
 Extensions are JavaScript packages that run inside a sandboxed JavaScriptCore context. Read the full guide at [dynamicisland.app/docs](https://dynamicisland.app/docs) or in [EXTENSIONS.md](EXTENSIONS.md).
 
+## Energy settings
+
+Settings -> General -> Power includes Normal, Smart, and Low Power modes. Smart reduces background refresh while the island is collapsed, while Low Power slows non-essential work and pauses inactive extension timers. See [docs/ENERGY.md](docs/ENERGY.md) for profiling notes and scheduler behavior.
+
 ---
 
 ## Contributing

--- a/SuperIsland/App/AppDelegate.swift
+++ b/SuperIsland/App/AppDelegate.swift
@@ -15,6 +15,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var updateCancellable: AnyCancellable?
     private var statusItem: NSStatusItem?
     private var menuBarDefaultsObserver: NSObjectProtocol?
+    private var powerStateObserver: NSObjectProtocol?
     private var quitHotkeyMonitor: Any?
     private var didBootstrapApp = false
     private static var fallbackSettingsWindowController: NSWindowController?
@@ -44,9 +45,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         AgentsStatusBridge.shared.stop()
     }
 
+    func applicationDidBecomeActive(_ notification: Notification) {
+        AppState.shared.setAppActive(true)
+    }
+
+    func applicationDidResignActive(_ notification: Notification) {
+        AppState.shared.setAppActive(false)
+    }
+
     deinit {
         if let quitHotkeyMonitor {
             NSEvent.removeMonitor(quitHotkeyMonitor)
+        }
+        if let powerStateObserver {
+            NotificationCenter.default.removeObserver(powerStateObserver)
         }
     }
 
@@ -56,6 +68,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         setupIslandWindow()
         applyMenuBarVisibility()
         observeMenuBarSetting()
+        observePowerState()
         initializeManagers()
     }
 
@@ -123,6 +136,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         extensions.discoverExtensions()
         extensions.activateDiscoveredExtensions()
         rebuildStatusMenu()
+        state.refreshEnergyState()
 
         UpdateChecker.shared.checkIfDue()
         observeUpdateState()
@@ -355,6 +369,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         ) { [weak self] _ in
             Task { @MainActor [weak self] in
                 self?.applyMenuBarVisibility()
+                ModuleRefreshScheduler.shared.refreshScheduling()
+                ExtensionManager.shared.syncRuntimeEnergyState()
+            }
+        }
+    }
+
+    private func observePowerState() {
+        guard powerStateObserver == nil else { return }
+        powerStateObserver = NotificationCenter.default.addObserver(
+            forName: Notification.Name.NSProcessInfoPowerStateDidChange,
+            object: nil,
+            queue: .main
+        ) { _ in
+            Task { @MainActor in
+                AppState.shared.refreshEnergyState()
             }
         }
     }

--- a/SuperIsland/App/AppState.swift
+++ b/SuperIsland/App/AppState.swift
@@ -233,12 +233,20 @@ final class AppState: ObservableObject {
                 didChangeState?(oldValue, currentState)
             }
             handleStateTransition(from: oldValue, to: currentState)
+            refreshEnergyState()
         }
     }
-    @Published var activeModule: ActiveModule? = nil
+    @Published var activeModule: ActiveModule? = nil {
+        didSet { refreshEnergyState() }
+    }
     @Published var previousModule: ActiveModule? = nil
-    @Published var fullExpandedSelectedTab: FullExpandedTab = .home
-    @Published var isHovering: Bool = false
+    @Published var fullExpandedSelectedTab: FullExpandedTab = .home {
+        didSet { refreshEnergyState() }
+    }
+    @Published var isHovering: Bool = false {
+        didSet { refreshEnergyState() }
+    }
+    @Published private(set) var isAppActive: Bool = true
     @Published private(set) var isShelfDragActive = false
     /// Set by IslandWindowController during overshoot animations to prevent
     /// hover-triggered dismiss from firing while the window frame is resizing.
@@ -286,6 +294,12 @@ final class AppState: ObservableObject {
     @AppStorage("onboarding.completed") var onboardingCompleted = false
     @AppStorage("debug.alwaysShowOnboarding") var debugAlwaysShowOnboarding = false
 
+    // Energy settings
+    @AppStorage("energy.mode") private var energyModeRawValue = EnergyMode.smart.rawValue
+    @AppStorage("energy.reduceAnimations") var reduceAnimations = false
+    @AppStorage("energy.disableBackgroundExtensionRefresh") var disableBackgroundExtensionRefresh = false
+    @AppStorage("energy.lowPowerSuggestionDoNotAskAgain") var lowPowerSuggestionDoNotAskAgain = false
+
     private var autoDismissWorkItem: DispatchWorkItem?
     private var fullExpandedDismissWorkItem: DispatchWorkItem?
     private var hoverActivationWorkItem: DispatchWorkItem?
@@ -300,11 +314,81 @@ final class AppState: ObservableObject {
     /// Recomputed per-call so the live bounce-amount setting takes effect
     /// without needing an app relaunch.
     var notchAnimation: Animation {
-        .interactiveSpring(
+        if shouldReduceAnimations {
+            return .easeOut(duration: 0.14)
+        }
+
+        return .interactiveSpring(
             duration: 0.5,
             extraBounce: bounceAmount,
             blendDuration: 0.125
         )
+    }
+
+    var energyMode: EnergyMode {
+        get { EnergyMode(rawValue: energyModeRawValue) ?? .smart }
+        set {
+            guard energyModeRawValue != newValue.rawValue else { return }
+            energyModeRawValue = newValue.rawValue
+            refreshEnergyState()
+        }
+    }
+
+    var effectiveEnergyMode: EnergyMode {
+        ProcessInfo.processInfo.isLowPowerModeEnabled ? .lowPower : energyMode
+    }
+
+    var shouldReduceAnimations: Bool {
+        reduceAnimations || effectiveEnergyMode == .lowPower || NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+    }
+
+    func setAppActive(_ active: Bool) {
+        guard isAppActive != active else { return }
+        isAppActive = active
+        refreshEnergyState()
+    }
+
+    func refreshEnergyState() {
+        let activity = IslandActivityState(
+            islandState: currentState,
+            activeModule: activeModule,
+            fullExpandedTab: fullExpandedSelectedTab,
+            isHovering: isHovering,
+            isAppActive: isAppActive
+        )
+        ModuleRefreshScheduler.shared.updateActivityState(activity)
+        ExtensionManager.shared.syncRuntimeEnergyState()
+    }
+
+    func isModuleVisibleForRefresh(_ module: ActiveModule) -> Bool {
+        isModuleVisibleForRefresh(
+            module,
+            state: IslandActivityState(
+                islandState: currentState,
+                activeModule: activeModule,
+                fullExpandedTab: fullExpandedSelectedTab,
+                isHovering: isHovering,
+                isAppActive: isAppActive
+            )
+        )
+    }
+
+    func isModuleVisibleForRefresh(_ module: ActiveModule, state: IslandActivityState) -> Bool {
+        if state.activeModule == module {
+            return true
+        }
+
+        if state.islandState == .fullExpanded,
+           case .module(let selectedModule) = state.fullExpandedTab,
+           selectedModule == module {
+            return true
+        }
+
+        if state.islandState == .compact, compactPresentationModule == module {
+            return true
+        }
+
+        return false
     }
 
     // MARK: - State Transitions

--- a/SuperIsland/Modules/Battery/BatteryManager.swift
+++ b/SuperIsland/Modules/Battery/BatteryManager.swift
@@ -37,8 +37,8 @@ final class BatteryManager: ObservableObject {
 
     private var runLoopSource: CFRunLoopSource?
     private var hasLoadedInitialSnapshot = false
-    private var historyTimer: Timer?
-    private var consumerPollTimer: Timer?
+    private var historyRefreshToken: ModuleRefreshToken?
+    private var consumerRefreshToken: ModuleRefreshToken?
     private let historySampleInterval: TimeInterval = 300
     private let maxHistorySamples = 72
 
@@ -68,22 +68,30 @@ final class BatteryManager: ObservableObject {
         appendHistorySample(force: true)
         refreshTopBatteryConsumers()
 
-        historyTimer?.invalidate()
-        historyTimer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
-            Task { @MainActor [weak self] in
-                self?.appendHistorySample(force: false)
-            }
+        historyRefreshToken = ModuleRefreshScheduler.shared.register(
+            id: "battery.history",
+            name: "Battery history sample",
+            module: .builtIn(.battery),
+            policy: .interval(historySampleInterval, tolerance: 60),
+            enabled: { AppState.shared.batteryEnabled }
+        ) { [weak self] in
+            self?.appendHistorySample(force: false)
         }
 
-        consumerPollTimer?.invalidate()
-        consumerPollTimer = Timer.scheduledTimer(withTimeInterval: 90, repeats: true) { [weak self] _ in
-            Task { @MainActor [weak self] in
-                self?.refreshTopBatteryConsumers()
-            }
+        consumerRefreshToken = ModuleRefreshScheduler.shared.register(
+            id: "battery.consumers",
+            name: "Battery consumer scan",
+            module: .builtIn(.battery),
+            policy: .visibleOnly(180, tolerance: 45),
+            enabled: { AppState.shared.batteryEnabled }
+        ) { [weak self] in
+            self?.refreshTopBatteryConsumers()
         }
     }
 
     func updateBatteryInfo() {
+        let wasPluggedIn = isPluggedIn
+
         guard let snapshot = IOPSCopyPowerSourcesInfo()?.takeRetainedValue(),
               let sources = IOPSCopyPowerSourcesList(snapshot)?.takeRetainedValue() as? [Any],
               let first = sources.first,
@@ -111,6 +119,10 @@ final class BatteryManager: ObservableObject {
         if let source = info[kIOPSPowerSourceStateKey] as? String {
             isPluggedIn = source == kIOPSACPowerValue
             powerSource = isPluggedIn ? "Power Adapter" : "Battery"
+
+            if hasLoadedInitialSnapshot, wasPluggedIn, !isPluggedIn {
+                EnergySuggestionPresenter.shared.suggestLowPower(reason: .battery)
+            }
         }
 
         if let timeToEmpty = info[kIOPSTimeToEmptyKey] as? Int, timeToEmpty > 0 {
@@ -156,7 +168,9 @@ final class BatteryManager: ObservableObject {
             guard let self else { return }
             let apps = Self.fetchTopBatteryConsumers()
             DispatchQueue.main.async {
-                self.topBatteryConsumers = apps
+                if self.topBatteryConsumers != apps {
+                    self.topBatteryConsumers = apps
+                }
                 self.batteryInsightsUpdatedAt = Date()
             }
         }
@@ -358,8 +372,12 @@ final class BatteryManager: ObservableObject {
         if let source = runLoopSource {
             CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .defaultMode)
         }
-        historyTimer?.invalidate()
-        consumerPollTimer?.invalidate()
+        let historyToken = historyRefreshToken
+        let consumerToken = consumerRefreshToken
+        Task { @MainActor in
+            ModuleRefreshScheduler.shared.unregister(historyToken)
+            ModuleRefreshScheduler.shared.unregister(consumerToken)
+        }
     }
 }
 

--- a/SuperIsland/Modules/Calendar/CalendarManager.swift
+++ b/SuperIsland/Modules/Calendar/CalendarManager.swift
@@ -1,5 +1,5 @@
 import Foundation
-import EventKit
+@preconcurrency import EventKit
 import Combine
 
 private extension Int {
@@ -21,9 +21,10 @@ final class CalendarManager: ObservableObject {
     @Published var upcomingWeekEvents: [(date: Date, events: [EKEvent])] = []
 
     private let store = EKEventStore()
-    private var refreshTimer: Timer?
+    private var refreshToken: ModuleRefreshToken?
     private var preEventTimer: Timer?
     private let calendarQueue = DispatchQueue(label: "superisland.calendar", qos: .userInitiated)
+    private var isObservingStoreChanges = false
     @Published var datesWithEvents: Set<Date> = []
 
     var preEventMinutes: Int {
@@ -45,7 +46,8 @@ final class CalendarManager: ObservableObject {
                     hasAccess = granted
                     if granted {
                         fetchTodayEvents()
-                        startRefreshTimer()
+                        registerRefresh()
+                        observeStoreChanges()
                         prefetchDatesWithEventsIfNeeded()
                     }
                 }
@@ -70,7 +72,9 @@ final class CalendarManager: ObservableObject {
             let events = storeRef.events(matching: predicate).sorted { $0.startDate < $1.startDate }
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
-                self.todayEvents = events
+                if !self.sameEvents(self.todayEvents, events) {
+                    self.todayEvents = events
+                }
                 self.nextEvent = events.first { $0.startDate > Date() }
                 self.schedulePreEventNotification()
                 self.fetchEventsForSelectedDate()
@@ -102,29 +106,49 @@ final class CalendarManager: ObservableObject {
                 AppState.shared.showHUD(module: .calendar, autoDismiss: false)
             }
         }
+        preEventTimer?.tolerance = min(30, max(1, interval * 0.05))
     }
 
     // MARK: - Refresh
 
-    private func startRefreshTimer() {
-        // Refresh every 5 minutes
-        refreshTimer = Timer.scheduledTimer(withTimeInterval: 300, repeats: true) { [weak self] _ in
-            Task { @MainActor in
-                self?.fetchTodayEvents()
-            }
+    private func registerRefresh() {
+        refreshToken = ModuleRefreshScheduler.shared.register(
+            id: "calendar.refresh",
+            name: "Calendar fallback refresh",
+            module: .builtIn(.calendar),
+            policy: .interval(600, tolerance: 120),
+            enabled: { AppState.shared.calendarEnabled }
+        ) { [weak self] in
+            self?.fetchTodayEvents()
         }
+    }
 
-        // Also refresh at midnight
+    private func observeStoreChanges() {
+        guard !isObservingStoreChanges else { return }
+        isObservingStoreChanges = true
+
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(dayChanged),
             name: .NSCalendarDayChanged,
             object: nil
         )
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(eventStoreChanged),
+            name: .EKEventStoreChanged,
+            object: store
+        )
     }
 
     @objc private func dayChanged() {
         fetchTodayEvents()
+    }
+
+    @objc private func eventStoreChanged() {
+        fetchTodayEvents()
+        prefetchDatesWithEventsIfNeeded()
     }
 
     // MARK: - Helpers
@@ -268,8 +292,22 @@ final class CalendarManager: ObservableObject {
         return calendar.date(from: components) ?? date
     }
 
+    private func sameEvents(_ lhs: [EKEvent], _ rhs: [EKEvent]) -> Bool {
+        guard lhs.count == rhs.count else { return false }
+        return zip(lhs, rhs).allSatisfy { left, right in
+            left.eventIdentifier == right.eventIdentifier
+                && left.title == right.title
+                && left.startDate == right.startDate
+                && left.endDate == right.endDate
+        }
+    }
+
     deinit {
-        refreshTimer?.invalidate()
+        let token = refreshToken
+        Task { @MainActor in
+            ModuleRefreshScheduler.shared.unregister(token)
+        }
         preEventTimer?.invalidate()
+        NotificationCenter.default.removeObserver(self)
     }
 }

--- a/SuperIsland/Modules/Connectivity/BluetoothManager.swift
+++ b/SuperIsland/Modules/Connectivity/BluetoothManager.swift
@@ -40,7 +40,7 @@ final class BluetoothManager: ObservableObject {
     @Published var lastConnectedDevice: BluetoothDeviceInfo?
     @Published var lastDisconnectedDeviceName: String?
 
-    private var pollTimer: Timer?
+    private var refreshToken: ModuleRefreshToken?
 
     private init() {
         updateDevices()
@@ -53,8 +53,13 @@ final class BluetoothManager: ObservableObject {
         // Register for Bluetooth connection notifications
         IOBluetoothDevice.register(forConnectNotifications: self, selector: #selector(deviceConnected(_:device:)))
 
-        // Poll periodically for device changes
-        pollTimer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: true) { [weak self] _ in
+        refreshToken = ModuleRefreshScheduler.shared.register(
+            id: "connectivity.bluetooth",
+            name: "Bluetooth fallback refresh",
+            module: .builtIn(.connectivity),
+            policy: .visibleOnly(60, tolerance: 15),
+            enabled: { AppState.shared.connectivityEnabled }
+        ) { [weak self] in
             self?.updateDevices()
         }
     }
@@ -136,6 +141,9 @@ final class BluetoothManager: ObservableObject {
     }
 
     deinit {
-        pollTimer?.invalidate()
+        let token = refreshToken
+        Task { @MainActor in
+            ModuleRefreshScheduler.shared.unregister(token)
+        }
     }
 }

--- a/SuperIsland/Modules/Connectivity/WiFiManager.swift
+++ b/SuperIsland/Modules/Connectivity/WiFiManager.swift
@@ -10,7 +10,7 @@ final class WiFiManager: ObservableObject {
     @Published var isConnected: Bool = false
 
     private let client = CWWiFiClient.shared()
-    private var pollTimer: Timer?
+    private var refreshToken: ModuleRefreshToken?
 
     private init() {
         updateWiFiInfo()
@@ -30,9 +30,16 @@ final class WiFiManager: ObservableObject {
 
         client.delegate = self
 
-        // Poll periodically as backup
-        pollTimer = Timer.scheduledTimer(withTimeInterval: 10.0, repeats: true) { [weak self] _ in
-            self?.updateWiFiInfo()
+        Task { @MainActor [weak self] in
+            self?.refreshToken = ModuleRefreshScheduler.shared.register(
+                id: "connectivity.wifi",
+                name: "Wi-Fi fallback refresh",
+                module: .builtIn(.connectivity),
+                policy: .visibleOnly(30, tolerance: 10),
+                enabled: { AppState.shared.connectivityEnabled }
+            ) { [weak self] in
+                self?.updateWiFiInfo()
+            }
         }
     }
 
@@ -76,7 +83,10 @@ final class WiFiManager: ObservableObject {
     }
 
     deinit {
-        pollTimer?.invalidate()
+        let token = refreshToken
+        Task { @MainActor in
+            ModuleRefreshScheduler.shared.unregister(token)
+        }
     }
 }
 

--- a/SuperIsland/Modules/Notifications/NotificationManager.swift
+++ b/SuperIsland/Modules/Notifications/NotificationManager.swift
@@ -62,8 +62,8 @@ final class NotificationManager: ObservableObject {
     private let maxNotifications = 10
     private let logMonitorQueue = DispatchQueue(label: "superisland.whatsapp-log-monitor", qos: .utility)
     private let deliveredMonitorQueue = DispatchQueue(label: "superisland.notifications-delivered-monitor", qos: .utility)
-    private var whatsappLogMonitorTimer: DispatchSourceTimer?
-    private var deliveredNotificationMonitorTimer: DispatchSourceTimer?
+    private var whatsappLogRefreshToken: ModuleRefreshToken?
+    private var deliveredNotificationRefreshToken: ModuleRefreshToken?
     private var seenWhatsAppEventIDs: [String] = []
     private var seenDeliveredNotificationIDs: [String] = []
     private let maxSeenWhatsAppEventIDs = 80
@@ -293,24 +293,27 @@ final class NotificationManager: ObservableObject {
     }
 
     private func startWhatsAppLogMonitor() {
-        let timer = DispatchSource.makeTimerSource(queue: logMonitorQueue)
-        timer.schedule(deadline: .now() + .milliseconds(300), repeating: .seconds(1))
-        timer.setEventHandler { [weak self] in
+        whatsappLogRefreshToken = ModuleRefreshScheduler.shared.register(
+            id: "notifications.whatsappLog",
+            name: "WhatsApp notification log scan",
+            module: .builtIn(.notifications),
+            policy: .interval(15, tolerance: 5),
+            enabled: { AppState.shared.notificationsEnabled }
+        ) { [weak self] in
             guard let self else { return }
 
-            let events = Self.fetchWhatsAppEventsFromUnifiedLog()
-            guard !events.isEmpty else { return }
+            self.logMonitorQueue.async { [weak self] in
+                let events = Self.fetchWhatsAppEventsFromUnifiedLog()
+                guard !events.isEmpty else { return }
 
-            Task { @MainActor [weak self] in
-                self?.ingestWhatsAppLogEvents(events)
+                Task { @MainActor [weak self] in
+                    self?.ingestWhatsAppLogEvents(events)
+                }
             }
         }
-
-        whatsappLogMonitorTimer = timer
-        timer.resume()
     }
 
-    private static func fetchWhatsAppEventsFromUnifiedLog() -> [WhatsAppLogEvent] {
+    nonisolated private static func fetchWhatsAppEventsFromUnifiedLog() -> [WhatsAppLogEvent] {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/log")
         process.arguments = [
@@ -899,27 +902,30 @@ final class NotificationManager: ObservableObject {
     }
 
     private func startDeliveredNotificationMonitor() {
-        let timer = DispatchSource.makeTimerSource(queue: deliveredMonitorQueue)
-        timer.schedule(deadline: .now() + .seconds(1), repeating: .seconds(2))
-        timer.setEventHandler { [weak self] in
-            Task { @MainActor [weak self] in
-                self?.pollDeliveredNotifications()
+        deliveredNotificationRefreshToken = ModuleRefreshScheduler.shared.register(
+            id: "notifications.delivered",
+            name: "Delivered notification scan",
+            module: .builtIn(.notifications),
+            policy: .interval(10, tolerance: 3),
+            enabled: { AppState.shared.notificationsEnabled }
+        ) { [weak self] in
+            guard let self else { return }
+            self.deliveredMonitorQueue.async { [weak self] in
+                Task { @MainActor [weak self] in
+                    self?.pollDeliveredNotifications()
+                }
             }
         }
-
-        deliveredNotificationMonitorTimer = timer
-        timer.resume()
     }
 
     @MainActor
     private func pollDeliveredNotifications() {
         UNUserNotificationCenter.current().getDeliveredNotifications { [weak self] delivered in
-            guard let self else { return }
-            let parsed = self.parseWhatsAppDeliveredNotifications(delivered)
-            guard !parsed.isEmpty else { return }
-
             Task { @MainActor [weak self] in
-                self?.ingestDeliveredNotifications(parsed)
+                guard let self else { return }
+                let parsed = self.parseWhatsAppDeliveredNotifications(delivered)
+                guard !parsed.isEmpty else { return }
+                self.ingestDeliveredNotifications(parsed)
             }
         }
     }
@@ -1531,10 +1537,12 @@ final class NotificationManager: ObservableObject {
     }
 
     deinit {
-        whatsappLogMonitorTimer?.cancel()
-        whatsappLogMonitorTimer = nil
-        deliveredNotificationMonitorTimer?.cancel()
-        deliveredNotificationMonitorTimer = nil
+        let whatsappToken = whatsappLogRefreshToken
+        let deliveredToken = deliveredNotificationRefreshToken
+        Task { @MainActor in
+            ModuleRefreshScheduler.shared.unregister(whatsappToken)
+            ModuleRefreshScheduler.shared.unregister(deliveredToken)
+        }
         DistributedNotificationCenter.default().removeObserver(self)
     }
 }

--- a/SuperIsland/Modules/NowPlaying/NowPlayingCompactView.swift
+++ b/SuperIsland/Modules/NowPlaying/NowPlayingCompactView.swift
@@ -184,6 +184,7 @@ struct EqualizerBarsView: NSViewRepresentable {
 }
 
 struct NowPlayingPlaybackCompactButton: View {
+    @EnvironmentObject var appState: AppState
     @ObservedObject private var manager = NowPlayingManager.shared
     @State private var isHovering = false
 
@@ -201,7 +202,7 @@ struct NowPlayingPlaybackCompactButton: View {
                             .frame(width: 18, height: 18)
                     } else {
                         EqualizerBarsView(
-                            isPlaying: true,
+                            isPlaying: !appState.shouldReduceAnimations,
                             barColor: manager.albumArtColor ?? .white
                         )
                         .frame(width: 20, height: 16)

--- a/SuperIsland/Modules/NowPlaying/NowPlayingManager.swift
+++ b/SuperIsland/Modules/NowPlaying/NowPlayingManager.swift
@@ -51,8 +51,9 @@ final class NowPlayingManager: ObservableObject {
     private var sendCommandFunc: MRMediaRemoteSendCommandFunction?
     private var setElapsedTimeFunc: MRMediaRemoteSetElapsedTimeFunction?
 
-    private var playbackTimer: Timer?
-    private var pollTimer: Timer?
+    private var sourceRefreshToken: ModuleRefreshToken?
+    private var playbackRefreshToken: ModuleRefreshToken?
+    private var lastPlaybackTickDate: Date?
     private var cancellables = Set<AnyCancellable>()
 
     // Track whether MediaRemote is providing data
@@ -92,7 +93,13 @@ final class NowPlayingManager: ObservableObject {
     // MARK: - Polling
 
     private func startPolling() {
-        pollTimer = Timer.scheduledTimer(withTimeInterval: 3.0, repeats: true) { [weak self] _ in
+        sourceRefreshToken = ModuleRefreshScheduler.shared.register(
+            id: "nowPlaying.source",
+            name: "Now Playing fallback refresh",
+            module: .builtIn(.nowPlaying),
+            policy: .interval(5, tolerance: 2),
+            enabled: { AppState.shared.nowPlayingEnabled }
+        ) { [weak self] in
             guard let self else { return }
             self.refreshPreferredSource()
         }
@@ -849,18 +856,40 @@ final class NowPlayingManager: ObservableObject {
     // MARK: - Playback Timer
 
     private func updatePlaybackTimer() {
-        playbackTimer?.invalidate()
-        playbackTimer = nil
+        ModuleRefreshScheduler.shared.unregister(playbackRefreshToken)
+        playbackRefreshToken = nil
+        lastPlaybackTickDate = nil
 
         guard isPlaying, duration > 0 else { return }
 
-        playbackTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
-            guard let self, self.isPlaying else { return }
-            self.elapsedTime += 1.0
-            if self.elapsedTime >= self.duration {
-                self.elapsedTime = self.duration
-                self.playbackTimer?.invalidate()
+        lastPlaybackTickDate = Date()
+        playbackRefreshToken = ModuleRefreshScheduler.shared.register(
+            id: "nowPlaying.progress",
+            name: "Now Playing progress",
+            module: .builtIn(.nowPlaying),
+            policy: .visibleOnly(1, tolerance: 0.2),
+            enabled: { [weak self] in
+                AppState.shared.nowPlayingEnabled && (self?.isPlaying ?? false)
             }
+        ) { [weak self] in
+            self?.advancePlaybackProgress()
+        }
+    }
+
+    private func advancePlaybackProgress() {
+        guard isPlaying, duration > 0 else {
+            updatePlaybackTimer()
+            return
+        }
+
+        let now = Date()
+        let delta = lastPlaybackTickDate.map { now.timeIntervalSince($0) } ?? 1
+        lastPlaybackTickDate = now
+
+        elapsedTime += min(max(delta, 0.5), 5) * max(playbackRate, 1)
+        if elapsedTime >= duration {
+            elapsedTime = duration
+            updatePlaybackTimer()
         }
     }
 
@@ -1232,13 +1261,18 @@ final class NowPlayingManager: ObservableObject {
         lastPausedChromeTabURL = ""
         currentBundleIdentifier = ""
         lastDetectedTitle = ""
-        playbackTimer?.invalidate()
-        playbackTimer = nil
+        ModuleRefreshScheduler.shared.unregister(playbackRefreshToken)
+        playbackRefreshToken = nil
+        lastPlaybackTickDate = nil
     }
 
     deinit {
-        playbackTimer?.invalidate()
-        pollTimer?.invalidate()
+        let sourceToken = sourceRefreshToken
+        let playbackToken = playbackRefreshToken
+        Task { @MainActor in
+            ModuleRefreshScheduler.shared.unregister(sourceToken)
+            ModuleRefreshScheduler.shared.unregister(playbackToken)
+        }
         adapterStreamTask?.cancel()
         if let adapterPipeHandler {
             Task {

--- a/SuperIsland/Modules/NowPlaying/SpectrogramView.swift
+++ b/SuperIsland/Modules/NowPlaying/SpectrogramView.swift
@@ -1,10 +1,12 @@
 import SwiftUI
 
 struct SpectrogramView: View {
+    @EnvironmentObject var appState: AppState
     @ObservedObject private var manager = NowPlayingManager.shared
 
     let barCount: Int = 32
     @State private var barHeights: [CGFloat] = []
+    @State private var animationTimer: Timer?
 
     var body: some View {
         HStack(spacing: 1.5) {
@@ -17,15 +19,25 @@ struct SpectrogramView: View {
         }
         .onAppear {
             barHeights = (0..<barCount).map { _ in CGFloat.random(in: 0.1...0.3) }
-            if manager.isPlaying {
+            if manager.isPlaying && !appState.shouldReduceAnimations {
                 animateBars()
             }
         }
+        .onDisappear {
+            stopAnimating()
+        }
         .onChange(of: manager.isPlaying) { _, playing in
-            if playing {
+            if playing && !appState.shouldReduceAnimations {
                 animateBars()
             } else {
                 quietBars()
+            }
+        }
+        .onChange(of: appState.shouldReduceAnimations) { _, reduced in
+            if reduced {
+                quietBars()
+            } else if manager.isPlaying {
+                animateBars()
             }
         }
     }
@@ -40,24 +52,33 @@ struct SpectrogramView: View {
     }
 
     private func animateBars() {
-        Timer.scheduledTimer(withTimeInterval: 0.15, repeats: true) { timer in
-            guard manager.isPlaying else {
-                timer.invalidate()
-                return
-            }
-            withAnimation(.easeInOut(duration: 0.15)) {
-                barHeights = (0..<barCount).map { index in
-                    // Simulate frequency spectrum: lower bars tend higher
-                    let base = 1.0 - (Double(index) / Double(barCount)) * 0.5
-                    return CGFloat(base * Double.random(in: 0.2...1.0))
+        guard animationTimer == nil else { return }
+        animationTimer = Timer.scheduledTimer(withTimeInterval: 0.3, repeats: true) { _ in
+            Task { @MainActor in
+                guard manager.isPlaying, !appState.shouldReduceAnimations else {
+                    stopAnimating()
+                    return
+                }
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    barHeights = (0..<barCount).map { index in
+                        // Simulate frequency spectrum: lower bars tend higher
+                        let base = 1.0 - (Double(index) / Double(barCount)) * 0.5
+                        return CGFloat(base * Double.random(in: 0.2...1.0))
+                    }
                 }
             }
         }
     }
 
     private func quietBars() {
+        stopAnimating()
         withAnimation(.easeOut(duration: 0.5)) {
             barHeights = (0..<barCount).map { _ in CGFloat(0.1) }
         }
+    }
+
+    private func stopAnimating() {
+        animationTimer?.invalidate()
+        animationTimer = nil
     }
 }

--- a/SuperIsland/Modules/SystemHUD/KeyboardBacklightManager.swift
+++ b/SuperIsland/Modules/SystemHUD/KeyboardBacklightManager.swift
@@ -7,7 +7,7 @@ final class KeyboardBacklightManager: ObservableObject {
 
     @Published var brightness: Float = 0.5
 
-    private var pollingTimer: Timer?
+    private var refreshToken: ModuleRefreshToken?
     private var connect: io_connect_t = 0
     private var serviceInitialized = false
 
@@ -40,7 +40,7 @@ final class KeyboardBacklightManager: ObservableObject {
     private func updateBrightness() {
         guard serviceInitialized else { return }
 
-        var inputCount: UInt32 = 1
+        let inputCount: UInt32 = 1
         var input: [UInt64] = [0]
         var outputCount: UInt32 = 1
         var output: [UInt64] = [0]
@@ -63,8 +63,16 @@ final class KeyboardBacklightManager: ObservableObject {
     // MARK: - Polling
 
     private func startPolling() {
-        pollingTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
-            self?.updateBrightness()
+        Task { @MainActor [weak self] in
+            self?.refreshToken = ModuleRefreshScheduler.shared.register(
+                id: "volume.keyboardBacklight",
+                name: "Keyboard backlight refresh",
+                module: .builtIn(.volumeHUD),
+                policy: .visibleOnly(2, tolerance: 0.5),
+                enabled: { AppState.shared.volumeHUDEnabled }
+            ) { [weak self] in
+                self?.updateBrightness()
+            }
         }
     }
 
@@ -74,7 +82,7 @@ final class KeyboardBacklightManager: ObservableObject {
         guard serviceInitialized else { return }
 
         let rawValue = UInt64(max(0, min(1, newBrightness)) * Float(0xFFF))
-        var inputCount: UInt32 = 2
+        let inputCount: UInt32 = 2
         var input: [UInt64] = [0, rawValue]
         var outputCount: UInt32 = 1
         var output: [UInt64] = [0]
@@ -94,7 +102,10 @@ final class KeyboardBacklightManager: ObservableObject {
     }
 
     deinit {
-        pollingTimer?.invalidate()
+        let token = refreshToken
+        Task { @MainActor in
+            ModuleRefreshScheduler.shared.unregister(token)
+        }
         if serviceInitialized {
             IOServiceClose(connect)
         }

--- a/SuperIsland/Modules/SystemHUD/VolumeManager.swift
+++ b/SuperIsland/Modules/SystemHUD/VolumeManager.swift
@@ -30,7 +30,7 @@ final class VolumeManager: ObservableObject {
     private var volumeListenerBlock: AudioObjectPropertyListenerBlock?
     private var muteListenerBlock: AudioObjectPropertyListenerBlock?
     private var deviceListenerBlock: AudioObjectPropertyListenerBlock?
-    private var mediaPollTimer: Timer?
+    private var mediaRefreshToken: ModuleRefreshToken?
     private let appleScriptQueue = DispatchQueue(label: "superisland.applescript", qos: .utility)
 
     private init() {
@@ -131,8 +131,13 @@ final class VolumeManager: ObservableObject {
     }
 
     private func startMediaMonitoring() {
-        mediaPollTimer?.invalidate()
-        mediaPollTimer = Timer.scheduledTimer(withTimeInterval: 4.0, repeats: true) { [weak self] _ in
+        mediaRefreshToken = ModuleRefreshScheduler.shared.register(
+            id: "volume.mediaApps",
+            name: "Media app volume refresh",
+            module: .builtIn(.volumeHUD),
+            policy: .visibleOnly(8, tolerance: 2),
+            enabled: { AppState.shared.volumeHUDEnabled }
+        ) { [weak self] in
             self?.refreshMediaAppVolumes()
         }
     }
@@ -448,6 +453,9 @@ final class VolumeManager: ObservableObject {
     }
 
     deinit {
-        mediaPollTimer?.invalidate()
+        let token = mediaRefreshToken
+        Task { @MainActor in
+            ModuleRefreshScheduler.shared.unregister(token)
+        }
     }
 }

--- a/SuperIsland/Modules/Teleprompter/TeleprompterExpandedView.swift
+++ b/SuperIsland/Modules/Teleprompter/TeleprompterExpandedView.swift
@@ -70,6 +70,7 @@ private final class _ScrollWheelNSView: NSView {
 struct TeleprompterScrollingTextView: View {
     let containerHeight: CGFloat
 
+    @EnvironmentObject var appState: AppState
     @ObservedObject private var manager = TeleprompterManager.shared
     @State private var offset: CGFloat = 0
     @State private var textHeight: CGFloat = 0
@@ -96,6 +97,10 @@ struct TeleprompterScrollingTextView: View {
         .onPreferenceChange(TextHeightKey.self) { textHeight = $0 }
         .onChange(of: manager.isPlaying) { _, playing in
             playing ? startScrolling() : stopScrolling()
+        }
+        .onChange(of: appState.shouldReduceAnimations) { _, _ in
+            guard manager.isPlaying else { return }
+            startScrolling()
         }
         .onChange(of: manager.resetToken) { _, _ in
             stopScrolling()
@@ -154,15 +159,17 @@ struct TeleprompterScrollingTextView: View {
 
     private func startScrolling() {
         stopScrolling()
-        scrollTimer = Timer.scheduledTimer(withTimeInterval: 1.0 / 60.0, repeats: true) { _ in
+        let framesPerSecond: Double = appState.shouldReduceAnimations ? 24 : 30
+        scrollTimer = Timer.scheduledTimer(withTimeInterval: 1.0 / framesPerSecond, repeats: true) { _ in
             Task { @MainActor in
                 guard manager.isPlaying else { return }
-                let delta = CGFloat(manager.scrollSpeed / 60.0)
+                let delta = CGFloat(manager.scrollSpeed / framesPerSecond)
                 let next = min(offset + delta, maxOffset)
                 offset = next
                 if maxOffset > 0, next >= maxOffset { manager.pause() }
             }
         }
+        scrollTimer?.tolerance = 0.01
     }
 
     private func stopScrolling() {

--- a/SuperIsland/Modules/Teleprompter/TeleprompterManager.swift
+++ b/SuperIsland/Modules/Teleprompter/TeleprompterManager.swift
@@ -136,6 +136,7 @@ final class TeleprompterManager: ObservableObject {
                 }
             }
         }
+        countdownTimer?.tolerance = 0.1
     }
 
     private func cancelCountdown() {

--- a/SuperIsland/Modules/Weather/WeatherManager.swift
+++ b/SuperIsland/Modules/Weather/WeatherManager.swift
@@ -32,14 +32,14 @@ final class WeatherManager: NSObject, ObservableObject {
 
     private let locationManager = CLLocationManager()
     private var lastFetchTime: Date?
-    private var refreshTimer: Timer?
+    private var refreshToken: ModuleRefreshToken?
 
     override private init() {
         super.init()
         locationManager.delegate = self
         locationManager.desiredAccuracy = kCLLocationAccuracyKilometer
         requestLocationAndFetch()
-        startRefreshTimer()
+        registerRefresh()
     }
 
     // MARK: - Location
@@ -228,17 +228,25 @@ final class WeatherManager: NSObject, ObservableObject {
 
     // MARK: - Refresh
 
-    private func startRefreshTimer() {
-        refreshTimer = Timer.scheduledTimer(
-            withTimeInterval: Constants.weatherRefreshInterval,
-            repeats: true
-        ) { [weak self] _ in
-            self?.requestLocationAndFetch()
+    private func registerRefresh() {
+        Task { @MainActor [weak self] in
+            self?.refreshToken = ModuleRefreshScheduler.shared.register(
+                id: "weather.refresh",
+                name: "Weather refresh",
+                module: .builtIn(.weather),
+                policy: .visibleOnly(Constants.weatherRefreshInterval, tolerance: 300),
+                enabled: { AppState.shared.weatherEnabled }
+            ) { [weak self] in
+                self?.requestLocationAndFetch()
+            }
         }
     }
 
     deinit {
-        refreshTimer?.invalidate()
+        let token = refreshToken
+        Task { @MainActor in
+            ModuleRefreshScheduler.shared.unregister(token)
+        }
     }
 }
 

--- a/SuperIsland/Settings/AdvancedSettingsView.swift
+++ b/SuperIsland/Settings/AdvancedSettingsView.swift
@@ -4,6 +4,7 @@ struct AdvancedSettingsView: View {
     @State private var showResetAlert = false
     @State private var screenOptions: [ScreenDetector.ScreenOption] = ScreenDetector.availableScreenOptions()
     @ObservedObject private var updateChecker = UpdateChecker.shared
+    @ObservedObject private var scheduler = ModuleRefreshScheduler.shared
     @EnvironmentObject var appState: AppState
 
     var body: some View {
@@ -34,6 +35,24 @@ struct AdvancedSettingsView: View {
             .onReceive(NotificationCenter.default.publisher(
                 for: NSApplication.didChangeScreenParametersNotification
             )) { _ in refreshScreenOptions() }
+
+            SettingSectionLabel(title: "Energy Diagnostics")
+            SettingGroup {
+                if scheduler.diagnostics.isEmpty {
+                    Text("No scheduled refresh jobs")
+                        .font(.system(size: 12))
+                        .foregroundColor(.secondary)
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 12)
+                } else {
+                    ForEach(Array(scheduler.diagnostics.enumerated()), id: \.element.id) { index, job in
+                        diagnosticRow(job)
+                        if index < scheduler.diagnostics.count - 1 {
+                            SettingRowDivider()
+                        }
+                    }
+                }
+            }
 
             SettingSectionLabel(title: "Debug")
             SettingGroup {
@@ -118,7 +137,7 @@ struct AdvancedSettingsView: View {
         switch updateChecker.checkState {
         case .checking:
             ProgressView().controlSize(.small)
-        case .updateAvailable(let version, let releaseURL, let downloadURL):
+        case .updateAvailable(_, let releaseURL, let downloadURL):
             Button("Update") {
                 if let downloadURL {
                     AutoUpdater.shared.start(downloadURL: downloadURL, releaseURL: releaseURL)
@@ -139,6 +158,41 @@ struct AdvancedSettingsView: View {
         let domain = Bundle.main.bundleIdentifier ?? "com.workview.SuperIsland"
         UserDefaults.standard.removePersistentDomain(forName: domain)
         UserDefaults.standard.synchronize()
+    }
+
+    private func diagnosticRow(_ job: EnergyDiagnosticsSnapshot) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(job.name)
+                    .font(.system(size: 13))
+                Text("\(job.moduleName) · \(job.policy)")
+                    .font(.system(size: 11))
+                    .foregroundColor(.secondary)
+                if let lastError = job.lastError {
+                    Text(lastError)
+                        .font(.system(size: 11))
+                        .foregroundColor(.red)
+                }
+            }
+            Spacer(minLength: 12)
+            VStack(alignment: .trailing, spacing: 3) {
+                Text(job.status)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(job.status == "Scheduled" ? .green : .secondary)
+                if let duration = job.lastRunDuration {
+                    Text("\(String(format: "%.0f", duration * 1000)) ms")
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundColor(.secondary)
+                }
+                if let nextFireDate = job.nextFireDate {
+                    Text("Next \(nextFireDate, style: .relative)")
+                        .font(.system(size: 11))
+                        .foregroundColor(.secondary)
+                }
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 11)
     }
 
     private func refreshScreenOptions() {

--- a/SuperIsland/Settings/GeneralSettingsView.swift
+++ b/SuperIsland/Settings/GeneralSettingsView.swift
@@ -141,6 +141,51 @@ struct GeneralSettingsView: View {
                 .padding(.horizontal, 16).padding(.vertical, 11)
             }
 
+            // Power
+            SettingSectionLabel(title: "Power")
+            SettingGroup {
+                HStack {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Power mode").font(.system(size: 13))
+                        Text(appState.energyMode.description)
+                            .font(.system(size: 11)).foregroundColor(.secondary)
+                    }
+                    Spacer(minLength: 12)
+                    Picker("", selection: energyModeBinding) {
+                        ForEach(EnergyMode.allCases) { mode in
+                            Text(mode.title).tag(mode)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                    .labelsHidden()
+                    .frame(width: 132)
+                }
+                .padding(.horizontal, 16).padding(.vertical, 12)
+
+                SettingRowDivider()
+                SettingToggleRow(
+                    title: "Reduce animations",
+                    description: "Use simpler motion for island transitions and visual effects.",
+                    isOn: $appState.reduceAnimations
+                )
+
+                SettingRowDivider()
+                SettingToggleRow(
+                    title: "Pause background extension refresh",
+                    description: "Keep inactive extensions quiet until they are visible or selected.",
+                    isOn: $appState.disableBackgroundExtensionRefresh
+                )
+
+                SettingRowDivider()
+                SettingToggleRow(
+                    title: "Low Power suggestions",
+                    description: "Offer Low Power mode when the Mac switches to battery or refresh work stays busy.",
+                    isOn: lowPowerSuggestionBinding
+                )
+            }
+            .onChange(of: appState.reduceAnimations) { _, _ in appState.refreshEnergyState() }
+            .onChange(of: appState.disableBackgroundExtensionRefresh) { _, _ in appState.refreshEnergyState() }
+
             // Behavior
             SettingSectionLabel(title: "Behavior")
             SettingGroup {
@@ -288,6 +333,20 @@ struct GeneralSettingsView: View {
 
     private func permissionGranted(_ permission: PermissionType) -> Bool {
         permissionStates[permission] ?? false
+    }
+
+    private var energyModeBinding: Binding<EnergyMode> {
+        Binding(
+            get: { appState.energyMode },
+            set: { appState.energyMode = $0 }
+        )
+    }
+
+    private var lowPowerSuggestionBinding: Binding<Bool> {
+        Binding(
+            get: { !appState.lowPowerSuggestionDoNotAskAgain },
+            set: { appState.lowPowerSuggestionDoNotAskAgain = !$0 }
+        )
     }
 
     private func refreshPermissionStates() {

--- a/SuperIsland/Utilities/EnergySuggestionPresenter.swift
+++ b/SuperIsland/Utilities/EnergySuggestionPresenter.swift
@@ -1,0 +1,62 @@
+import AppKit
+
+enum EnergySuggestionReason {
+    case battery
+    case sustainedActivity
+
+    var message: String {
+        switch self {
+        case .battery:
+            return "Your Mac switched to battery power. SuperIsland can reduce background refresh and pause inactive extension work until you switch back."
+        case .sustainedActivity:
+            return "SuperIsland has been doing sustained background refresh work. Low Power mode can slow non-essential refresh until you need it again."
+        }
+    }
+}
+
+@MainActor
+final class EnergySuggestionPresenter {
+    static let shared = EnergySuggestionPresenter()
+
+    private let lastPromptKey = "energy.lowPowerSuggestion.lastPromptAt"
+    private var isShowing = false
+
+    private init() {}
+
+    func suggestLowPower(reason: EnergySuggestionReason) {
+        let appState = AppState.shared
+        guard appState.energyMode != .lowPower else { return }
+        guard !appState.lowPowerSuggestionDoNotAskAgain else { return }
+        guard !isShowing else { return }
+
+        let lastPrompt = UserDefaults.standard.double(forKey: lastPromptKey)
+        if lastPrompt > 0, Date().timeIntervalSince1970 - lastPrompt < 24 * 60 * 60 {
+            return
+        }
+
+        isShowing = true
+        UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: lastPromptKey)
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            let alert = NSAlert()
+            alert.messageText = "Use Low Power mode?"
+            alert.informativeText = reason.message
+            alert.alertStyle = .informational
+            alert.addButton(withTitle: "Enable Low Power")
+            alert.addButton(withTitle: "Not Now")
+            alert.addButton(withTitle: "Do Not Ask Again")
+
+            let response = alert.runModal()
+            switch response {
+            case .alertFirstButtonReturn:
+                AppState.shared.energyMode = .lowPower
+            case .alertThirdButtonReturn:
+                AppState.shared.lowPowerSuggestionDoNotAskAgain = true
+            default:
+                break
+            }
+            self.isShowing = false
+        }
+    }
+}

--- a/SuperIsland/Utilities/MediaKeyInterceptor.swift
+++ b/SuperIsland/Utilities/MediaKeyInterceptor.swift
@@ -133,6 +133,7 @@ final class MediaKeyInterceptor {
                 self.cancelRetry()
             }
         }
+        timer.tolerance = 0.5
         RunLoop.main.add(timer, forMode: .common)
         retryTimer = timer
     }

--- a/SuperIsland/Utilities/ModuleRefreshScheduler.swift
+++ b/SuperIsland/Utilities/ModuleRefreshScheduler.swift
@@ -1,0 +1,346 @@
+import Foundation
+import SwiftUI
+
+enum EnergyMode: String, CaseIterable, Identifiable {
+    case normal
+    case smart
+    case lowPower
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .normal: return "Normal"
+        case .smart: return "Smart"
+        case .lowPower: return "Low Power"
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .normal:
+            return "Keep refresh behavior responsive."
+        case .smart:
+            return "Reduce background work while collapsed and restore quickly on hover."
+        case .lowPower:
+            return "Slow non-essential refresh and pause inactive extension work."
+        }
+    }
+}
+
+enum ModuleRefreshPolicy: Equatable {
+    case eventDriven
+    case interval(TimeInterval, tolerance: TimeInterval)
+    case activeOnly(TimeInterval, tolerance: TimeInterval)
+    case visibleOnly(TimeInterval, tolerance: TimeInterval)
+    case manual
+
+    var label: String {
+        switch self {
+        case .eventDriven:
+            return "Event driven"
+        case .interval(let interval, _):
+            return "Every \(Self.format(interval))"
+        case .activeOnly(let interval, _):
+            return "Active every \(Self.format(interval))"
+        case .visibleOnly(let interval, _):
+            return "Visible every \(Self.format(interval))"
+        case .manual:
+            return "Manual"
+        }
+    }
+
+    private static func format(_ interval: TimeInterval) -> String {
+        if interval >= 60 {
+            return "\(Int(interval / 60))m"
+        }
+        return "\(String(format: "%.1f", interval))s"
+    }
+}
+
+struct ModuleRefreshToken: Hashable {
+    fileprivate let id: String
+}
+
+struct IslandActivityState: Equatable {
+    var islandState: IslandState
+    var activeModule: ActiveModule?
+    var fullExpandedTab: FullExpandedTab
+    var isHovering: Bool
+    var isAppActive: Bool
+}
+
+struct EnergyDiagnosticsSnapshot: Identifiable, Equatable {
+    let id: String
+    let name: String
+    let moduleName: String
+    let policy: String
+    let status: String
+    let nextFireDate: Date?
+    let lastRunDate: Date?
+    let lastRunDuration: TimeInterval?
+    let lastError: String?
+}
+
+@MainActor
+final class ModuleRefreshScheduler: ObservableObject {
+    static let shared = ModuleRefreshScheduler()
+
+    @Published private(set) var diagnostics: [EnergyDiagnosticsSnapshot] = []
+
+    private struct Job {
+        let id: String
+        let name: String
+        let module: ActiveModule?
+        let policy: ModuleRefreshPolicy
+        let enabled: @MainActor () -> Bool
+        let action: @MainActor () -> Void
+        var timer: Timer?
+        var nextFireDate: Date?
+        var lastRunDate: Date?
+        var lastRunDuration: TimeInterval?
+        var lastError: String?
+        var status: String = "Scheduled"
+    }
+
+    private var jobs: [String: Job] = [:]
+    private var recentActivity: [(date: Date, duration: TimeInterval)] = []
+    private var activityState = IslandActivityState(
+        islandState: .compact,
+        activeModule: nil,
+        fullExpandedTab: .home,
+        isHovering: false,
+        isAppActive: true
+    )
+
+    private init() {}
+
+    @discardableResult
+    func register(
+        id: String,
+        name: String,
+        module: ActiveModule? = nil,
+        policy: ModuleRefreshPolicy,
+        enabled: @escaping @MainActor () -> Bool = { true },
+        action: @escaping @MainActor () -> Void
+    ) -> ModuleRefreshToken {
+        unregister(id: id)
+
+        jobs[id] = Job(
+            id: id,
+            name: name,
+            module: module,
+            policy: policy,
+            enabled: enabled,
+            action: action
+        )
+        reschedule(id: id, runIfNewlyVisible: false)
+        updateDiagnostics()
+        return ModuleRefreshToken(id: id)
+    }
+
+    func unregister(_ token: ModuleRefreshToken?) {
+        guard let token else { return }
+        unregister(id: token.id)
+    }
+
+    func unregister(id: String) {
+        jobs[id]?.timer?.invalidate()
+        jobs.removeValue(forKey: id)
+        updateDiagnostics()
+    }
+
+    func updateActivityState(_ nextState: IslandActivityState) {
+        guard activityState != nextState else { return }
+        let previousState = activityState
+        activityState = nextState
+
+        for id in jobs.keys {
+            let becameVisible = jobIsVisible(jobs[id]) && !jobIsVisible(jobs[id], state: previousState)
+            reschedule(id: id, runIfNewlyVisible: becameVisible)
+        }
+        updateDiagnostics()
+    }
+
+    func refreshScheduling() {
+        for id in jobs.keys {
+            reschedule(id: id, runIfNewlyVisible: false)
+        }
+        updateDiagnostics()
+    }
+
+    func runNow(id: String) {
+        guard jobs[id] != nil else { return }
+        run(id: id)
+    }
+
+    private func reschedule(id: String, runIfNewlyVisible: Bool) {
+        guard var job = jobs[id] else { return }
+
+        job.timer?.invalidate()
+        job.timer = nil
+        job.nextFireDate = nil
+
+        guard job.enabled() else {
+            job.status = "Disabled"
+            jobs[id] = job
+            return
+        }
+
+        guard let schedule = effectiveSchedule(for: job) else {
+            job.status = passiveStatus(for: job)
+            jobs[id] = job
+            return
+        }
+
+        let interval = schedule.interval
+        let nextFireDate = Date().addingTimeInterval(interval)
+        let timer = Timer(timeInterval: interval, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.run(id: id)
+            }
+        }
+        timer.tolerance = schedule.tolerance
+        RunLoop.main.add(timer, forMode: .common)
+
+        job.timer = timer
+        job.nextFireDate = nextFireDate
+        job.status = "Scheduled"
+        jobs[id] = job
+
+        if runIfNewlyVisible, shouldRunWhenBecomingVisible(job) {
+            run(id: id)
+        }
+    }
+
+    private func run(id: String) {
+        guard var job = jobs[id], job.enabled() else {
+            reschedule(id: id, runIfNewlyVisible: false)
+            return
+        }
+
+        guard effectiveSchedule(for: job) != nil else {
+            reschedule(id: id, runIfNewlyVisible: false)
+            return
+        }
+
+        let start = Date()
+        job.action()
+        let duration = Date().timeIntervalSince(start)
+        job.lastRunDate = start
+        job.lastRunDuration = duration
+        job.lastError = nil
+        jobs[id] = job
+
+        recordActivity(duration: duration)
+        updateDiagnostics()
+    }
+
+    private func effectiveSchedule(for job: Job) -> (interval: TimeInterval, tolerance: TimeInterval)? {
+        switch job.policy {
+        case .eventDriven, .manual:
+            return nil
+        case .interval(let interval, let tolerance):
+            return adjustedSchedule(interval: interval, tolerance: tolerance, module: job.module)
+        case .activeOnly(let interval, let tolerance):
+            guard jobIsVisible(job) || activityState.isHovering else { return nil }
+            return adjustedSchedule(interval: interval, tolerance: tolerance, module: job.module)
+        case .visibleOnly(let interval, let tolerance):
+            guard jobIsVisible(job) else { return nil }
+            return adjustedSchedule(interval: interval, tolerance: tolerance, module: job.module)
+        }
+    }
+
+    private func adjustedSchedule(
+        interval: TimeInterval,
+        tolerance: TimeInterval,
+        module: ActiveModule?
+    ) -> (interval: TimeInterval, tolerance: TimeInterval) {
+        let mode = AppState.shared.effectiveEnergyMode
+        var adjustedInterval = max(interval, minimumInterval(for: module))
+        var adjustedTolerance = max(tolerance, adjustedInterval * 0.15)
+
+        if mode == .smart,
+           activityState.islandState == .compact,
+           !activityState.isHovering,
+           module.map({ !AppState.shared.isModuleVisibleForRefresh($0) }) ?? true {
+            adjustedInterval = max(adjustedInterval * 4, 30)
+            adjustedTolerance = max(adjustedTolerance, adjustedInterval * 0.35)
+        } else if mode == .lowPower {
+            adjustedInterval = max(adjustedInterval * 3, 60)
+            adjustedTolerance = max(adjustedTolerance, adjustedInterval * 0.4)
+        }
+
+        return (adjustedInterval, adjustedTolerance)
+    }
+
+    private func minimumInterval(for module: ActiveModule?) -> TimeInterval {
+        switch module {
+        case .extension_:
+            return AppState.shared.effectiveEnergyMode == .normal ? 2 : 5
+        default:
+            return 1
+        }
+    }
+
+    private func passiveStatus(for job: Job) -> String {
+        switch job.policy {
+        case .eventDriven:
+            return "Event driven"
+        case .manual:
+            return "Manual"
+        case .activeOnly, .visibleOnly:
+            return job.enabled() ? "Paused" : "Disabled"
+        case .interval:
+            return "Paused"
+        }
+    }
+
+    private func jobIsVisible(_ job: Job?) -> Bool {
+        jobIsVisible(job, state: activityState)
+    }
+
+    private func jobIsVisible(_ job: Job?, state: IslandActivityState) -> Bool {
+        guard let module = job?.module else {
+            return state.isAppActive || state.isHovering
+        }
+        return AppState.shared.isModuleVisibleForRefresh(module, state: state)
+    }
+
+    private func shouldRunWhenBecomingVisible(_ job: Job) -> Bool {
+        guard job.enabled() else { return false }
+        guard let lastRunDate = job.lastRunDate else { return true }
+        guard let schedule = effectiveSchedule(for: job) else { return false }
+        return Date().timeIntervalSince(lastRunDate) >= min(schedule.interval, 5)
+    }
+
+    private func recordActivity(duration: TimeInterval) {
+        let now = Date()
+        recentActivity.append((now, duration))
+        recentActivity.removeAll { now.timeIntervalSince($0.date) > 120 }
+
+        let totalDuration = recentActivity.reduce(0) { $0 + $1.duration }
+        if recentActivity.count >= 80 || totalDuration >= 8 {
+            EnergySuggestionPresenter.shared.suggestLowPower(reason: .sustainedActivity)
+            recentActivity.removeAll()
+        }
+    }
+
+    private func updateDiagnostics() {
+        diagnostics = jobs.values
+            .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+            .map { job in
+                EnergyDiagnosticsSnapshot(
+                    id: job.id,
+                    name: job.name,
+                    moduleName: job.module?.displayName ?? "App",
+                    policy: job.policy.label,
+                    status: job.status,
+                    nextFireDate: job.nextFireDate,
+                    lastRunDate: job.lastRunDate,
+                    lastRunDuration: job.lastRunDuration,
+                    lastError: job.lastError
+                )
+            }
+    }
+}

--- a/SuperIsland/Views/IslandContainerView.swift
+++ b/SuperIsland/Views/IslandContainerView.swift
@@ -7,7 +7,7 @@ struct IslandContainerView: View {
     @State private var isHoveringNextButton = false
     @State private var isShelfDropTargeted = false
     @State private var shelfDragEndWorkItem: DispatchWorkItem?
-    private let hoverValidationTimer = Timer.publish(every: 0.5, on: .main, in: .common).autoconnect()
+    private let hoverValidationTimer = Timer.publish(every: 1.0, on: .main, in: .common).autoconnect()
 
     var body: some View {
         // No GeometryReader — just like NotchDrop. The surface sizes
@@ -30,6 +30,7 @@ struct IslandContainerView: View {
             setCycleButtonHover(false, forward: true)
         }
         .onReceive(hoverValidationTimer) { _ in
+            guard appState.isHovering || appState.currentState != .compact else { return }
             validateHoverState()
         }
     }
@@ -102,7 +103,7 @@ struct IslandContainerView: View {
                 appState.presentShelfAfterDrop()
             }
         }
-        .animation(.spring(response: 0.48, dampingFraction: 0.8), value: appState.activeModule)
+        .animation(islandSurfaceAnimation, value: appState.activeModule)
     }
 
     // MARK: - Content
@@ -175,6 +176,10 @@ struct IslandContainerView: View {
 
     private var keyShadowYOffset: CGFloat {
         appState.currentState == .compact ? 0 : 10
+    }
+
+    private var islandSurfaceAnimation: Animation {
+        appState.shouldReduceAnimations ? .easeOut(duration: 0.12) : .spring(response: 0.48, dampingFraction: 0.8)
     }
 
     // MARK: - Expanded Layout

--- a/docs/ENERGY.md
+++ b/docs/ENERGY.md
@@ -1,0 +1,42 @@
+# Energy behavior
+
+SuperIsland uses a central refresh scheduler for recurring module and extension work. Managers register the work they need, the scheduler applies the current island state and power mode, and timers use tolerance so macOS can coalesce wakeups.
+
+## Power modes
+
+- Normal: keeps refresh behavior responsive.
+- Smart: reduces background refresh while the island is collapsed and restores quickly when the user hovers, focuses, or expands the island.
+- Low Power: slows non-essential refresh, reduces motion, and pauses inactive extension timers.
+
+The setting is available in Settings -> General -> Power.
+If macOS Low Power Mode is active, scheduler behavior follows the Low Power profile without changing the saved SuperIsland setting.
+
+## Current scheduler coverage
+
+- Weather refresh is cached and only scheduled while the weather module is visible.
+- Calendar uses EventKit change notifications plus a low-frequency fallback refresh.
+- Battery updates are event-driven where possible; history and consumer scans run through the scheduler.
+- Connectivity uses Wi-Fi and Bluetooth events plus slower visible-only fallbacks.
+- Now Playing keeps provider refresh conservative and only advances progress while visible.
+- Notifications avoid one-second log polling and run lower-frequency scheduled scans.
+- Extension refresh jobs are scheduler-backed, and inactive extension timers can be suspended by Smart, Low Power, or the background-refresh setting.
+
+## Verification notes for PR-01
+
+Before this change, several modules owned independent repeating timers, including one-second notification log scans, half-second extension refresh, and visible animation timers without lifecycle cleanup. After this change, recurring work is registered centrally, inactive work can pause, and diagnostics in Settings -> Advanced show active jobs, status, next fire time, and last run cost.
+
+Suggested local checks:
+
+```bash
+xcodegen generate
+xcodebuild -project SuperIsland.xcodeproj -scheme SuperIsland -configuration Debug build
+git diff --check
+```
+
+Manual smoke checks:
+
+- Launch SuperIsland, leave the island collapsed, and confirm Activity Monitor does not show persistent high CPU.
+- Open Settings -> Advanced and confirm scheduler jobs are paused or scheduled as expected.
+- Switch between Normal, Smart, and Low Power modes.
+- Disable modules and confirm their scheduled work stops.
+- Play media and confirm Now Playing remains responsive when visible.


### PR DESCRIPTION
Summary:
- Adds a central refresh scheduler for built-in modules and extensions.
- Pauses non-essential work when modules are hidden, disabled, or the island is collapsed.
- Adds Normal, Smart, and Low Power controls plus diagnostics for active refresh jobs.
- Addresses energy-related reports in #67, #68, and #69.

Validation:
- `git diff --check` passed.
- Direct Swift typecheck of app sources passed with the package-backed analytics source excluded because package resolution depends on generated project setup.
- `xcodebuild -version` reported Xcode 26.5.
- `xcodegen generate` could not run because `xcodegen` is unavailable locally.
- Full `xcodebuild` could not run because the project file is generated and is not present without XcodeGen.

Screenshots needed:
- Settings -> General -> Power section.
- Settings -> Advanced -> Energy Diagnostics section with scheduled jobs visible.

Risk notes:
- Refresh cadence changes can affect perceived freshness for notifications, extensions, and Now Playing fallback updates.
- Calendar still has existing Swift concurrency warnings around EventKit values used off the main queue.
- Weather still has existing macOS 26 deprecation warnings for reverse geocoding APIs.
- Manual idle-energy verification in Activity Monitor or Instruments is still needed on a real Mac session.