### PR TITLE
Add universal build verification and Homebrew Cask packaging

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,15 @@ Check the [Issues](https://github.com/shobhit99/superisland/issues) tab. Issues 
 
 ---
 
+## Release and packaging changes
+
+- Keep local builds simple: `./scripts/build-dmg.sh` should work without notarization credentials
+- Use `./scripts/build-and-release.sh --dry-run` before changing release steps
+- Use `./scripts/verify-universal-build.sh` for release app bundles
+- Update [docs/RELEASE.md](docs/RELEASE.md) when release, signing, notarization, or Homebrew packaging steps change
+
+---
+
 ## Adding extensions
 
 Extensions are the easiest way to contribute without touching Swift. See [dynamicisland.app/docs](https://dynamicisland.app/docs) or [EXTENSIONS.md](EXTENSIONS.md) for a full guide. Drop your extension in `Extensions/` and it will be picked up automatically during development.

--- a/PR_NOTES_PR-02.md
+++ b/PR_NOTES_PR-02.md
@@ -1,0 +1,40 @@
+# PR-02 Notes
+
+Title: Add universal build verification and Homebrew Cask packaging
+
+Branch: `distribution/universal-build-homebrew-notarization`
+
+Linked issue:
+- #60 Support brew install
+
+Summary:
+- Updates local and release DMG scripts to target universal `arm64 x86_64` builds.
+- Adds a shared Node.js runtime bundling script that creates a universal bundled runtime.
+- Adds a universal build verification script for app and runtime binaries.
+- Adds dry-run preflight support and clearer missing-command/signing-credential errors.
+- Adds a Homebrew Cask template under `packaging/homebrew/`.
+- Adds release, notarization, verification, and Cask update documentation.
+- Keeps unsigned local builds separate from signed maintainer release builds.
+
+Validation:
+- `bash -n` passed for release and packaging scripts.
+- `ruby -c packaging/homebrew/superisland.rb` passed.
+- `git diff --check` passed.
+- `./scripts/bundle-node-runtime.sh build/SuperIsland.app --dry-run` passed.
+- `./scripts/verify-universal-build.sh --help` passed.
+- `./scripts/build-dmg.sh --dry-run` failed clearly because `xcodegen` is unavailable locally.
+- `./scripts/build-and-release.sh --dry-run` failed clearly because `xcodegen` is unavailable locally.
+- `xcodebuild -version` reported Xcode 26.5.
+- `xcodegen generate` could not run because `xcodegen` is unavailable locally.
+
+Screenshots needed:
+- None. This PR changes release scripts and documentation only.
+
+Risk notes:
+- Universal runtime bundling downloads two Node.js archives instead of one, so release builds depend on both upstream archive URLs.
+- Maintainers should run the full release script on a machine with XcodeGen, signing credentials, and notarization credentials before publishing.
+- The Homebrew Cask keeps a placeholder SHA256 until a real release DMG is uploaded.
+
+PR status:
+- Branch is prepared locally.
+- PR was not opened locally because the GitHub CLI is unavailable.

--- a/README.md
+++ b/README.md
@@ -41,9 +41,15 @@ Select the `SuperIsland` scheme, choose your Mac as the destination, and hit Run
 
 ---
 
-## Building a release DMG
+## Building a DMG
 
-Requires a Developer ID certificate and notarization credentials. Copy `.env.example` to `.env` and fill in:
+For a quick unsigned local build:
+
+```bash
+./scripts/build-dmg.sh
+```
+
+For a signed release, use a Developer ID certificate and notarization credentials. Copy `.env.template` to `.env` and fill in:
 
 ```
 APPLE_ID=you@example.com
@@ -58,12 +64,14 @@ Then run:
 ./scripts/build-and-release.sh
 ```
 
-This archives, exports, notarizes, and produces a signed `build/SuperIsland.dmg`.
+This archives a universal app, bundles a universal runtime, notarizes the DMG, and produces `build/SuperIsland.dmg`.
 
-For a quick unsigned local build:
+Release and Homebrew packaging notes are in [docs/RELEASE.md](docs/RELEASE.md). A Homebrew Cask template is available at [packaging/homebrew/superisland.rb](packaging/homebrew/superisland.rb).
+
+To verify a built app bundle:
 
 ```bash
-./scripts/build-dmg.sh
+./scripts/verify-universal-build.sh build/SuperIsland.app --skip-signature
 ```
 
 ---

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,99 @@
+# Release checklist
+
+This checklist separates local contributor builds from signed maintainer releases. Local builds can stay unsigned or development-signed. Public releases should be Developer ID signed, notarized, stapled, and verified before publishing.
+
+## Local unsigned DMG
+
+```bash
+./scripts/build-dmg.sh
+```
+
+The local script builds a universal Release app, bundles a universal Node.js runtime, creates `build/SuperIsland.dmg`, and signs with a local development certificate only when one is available.
+
+To check the script without building:
+
+```bash
+./scripts/build-dmg.sh --dry-run
+```
+
+## Signed release DMG
+
+Create `.env` from `.env.template` and fill in:
+
+```bash
+APPLE_ID=you@example.com
+APP_SPECIFIC_PASSWORD=xxxx-xxxx-xxxx-xxxx
+TEAM_ID=XXXXXXXXXX
+SIGNING_IDENTITY=Developer ID Application: Your Name (TEAMID)
+```
+
+Then run:
+
+```bash
+./scripts/build-and-release.sh
+```
+
+To validate commands and credentials without cleaning or building:
+
+```bash
+./scripts/build-and-release.sh --dry-run
+```
+
+The release script archives a universal app, bundles a universal Node.js runtime, signs the app and DMG, submits the DMG for notarization, staples the ticket, and verifies the final DMG.
+
+## Universal binary verification
+
+After building an app bundle, verify the app binary and bundled runtime:
+
+```bash
+./scripts/verify-universal-build.sh build/SuperIsland.app --skip-signature
+```
+
+For a signed release app, run the strict verification:
+
+```bash
+./scripts/verify-universal-build.sh build/SuperIsland.app
+```
+
+The strict check runs:
+
+```bash
+lipo -info build/SuperIsland.app/Contents/MacOS/SuperIsland
+codesign --verify --deep --strict --verbose=2 build/SuperIsland.app
+spctl --assess --type execute --verbose build/SuperIsland.app
+```
+
+## Homebrew Cask update
+
+The template lives at `packaging/homebrew/superisland.rb`.
+
+After uploading a release DMG:
+
+```bash
+shasum -a 256 build/SuperIsland.dmg
+```
+
+Update:
+
+- `version`
+- `sha256`
+- `url`, if the release asset path changes
+
+Then test locally with Homebrew:
+
+```bash
+brew install --cask --no-quarantine ./packaging/homebrew/superisland.rb
+brew uninstall --cask superisland
+```
+
+## Release checklist
+
+- Run `xcodegen generate`.
+- Build and smoke-test the app locally.
+- Run `./scripts/build-and-release.sh --dry-run`.
+- Run `./scripts/build-and-release.sh`.
+- Confirm `lipo -info` reports both `arm64` and `x86_64` for the app binary and bundled runtime.
+- Confirm notarization succeeds and the ticket is stapled.
+- Confirm `spctl` accepts the release artifact.
+- Update the Homebrew Cask version and SHA256.
+- Upload the DMG and publish release notes.

--- a/packaging/homebrew/superisland.rb
+++ b/packaging/homebrew/superisland.rb
@@ -1,0 +1,19 @@
+cask "superisland" do
+  version "1.0.7"
+  sha256 "REPLACE_WITH_RELEASE_DMG_SHA256"
+
+  url "https://github.com/shobhit99/superisland/releases/download/v#{version}/SuperIsland.dmg"
+  name "SuperIsland"
+  desc "Interactive island for the Mac notch"
+  homepage "https://dynamicisland.app/"
+
+  depends_on macos: ">= :sonoma"
+
+  app "SuperIsland.app"
+
+  zap trash: [
+    "~/Library/Application Support/SuperIsland",
+    "~/Library/Caches/com.workview.SuperIsland",
+    "~/Library/Preferences/com.workview.SuperIsland.plist",
+  ]
+end

--- a/scripts/build-and-release.sh
+++ b/scripts/build-and-release.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
-# Usage: ./scripts/build-and-release.sh
+# Usage: ./scripts/build-and-release.sh [--dry-run]
 # Requires: APPLE_ID, APP_SPECIFIC_PASSWORD, TEAM_ID, SIGNING_IDENTITY env vars
 # or reads from .env file
 
 set -euo pipefail
 
 # --- Configuration (from env or .env file) ---
-source .env 2>/dev/null || true
+if [ -f .env ]; then
+  source .env
+fi
+DRY_RUN=0
 APP_NAME="SuperIsland"
 SCHEME="${APP_NAME}"
 BUILD_DIR="build"
@@ -16,11 +19,54 @@ DMG_PATH="${BUILD_DIR}/${APP_NAME}.dmg"
 DMG_STAGING_DIR="${BUILD_DIR}/dmg-root"
 ENTITLEMENTS="SuperIsland/SuperIsland.entitlements"
 
-# Required env vars
-: "${APPLE_ID:?Set APPLE_ID in .env}"
-: "${APP_SPECIFIC_PASSWORD:?Set APP_SPECIFIC_PASSWORD in .env}"
-: "${TEAM_ID:?Set TEAM_ID in .env}"
-: "${SIGNING_IDENTITY:?Set SIGNING_IDENTITY in .env (e.g., 'Developer ID Application: Your Name (TEAMID)')}"
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=1
+      ;;
+    -h|--help)
+      echo "Usage: $0 [--dry-run]"
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unexpected argument: $1"
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "ERROR: required command not found: $1"
+    exit 1
+  fi
+}
+
+require_env() {
+  local name="$1"
+  local help="$2"
+  if [ -z "${!name:-}" ]; then
+    echo "ERROR: missing ${name}. ${help}"
+    exit 1
+  fi
+}
+
+for command_name in xcodegen xcodebuild curl tar lipo codesign hdiutil xcrun spctl; do
+  require_command "${command_name}"
+done
+
+require_env "APPLE_ID" "Set APPLE_ID in .env."
+require_env "APP_SPECIFIC_PASSWORD" "Set APP_SPECIFIC_PASSWORD in .env."
+require_env "TEAM_ID" "Set TEAM_ID in .env."
+require_env "SIGNING_IDENTITY" "Set SIGNING_IDENTITY in .env, for example: Developer ID Application: Your Name (TEAMID)."
+
+if [ "${DRY_RUN}" = "1" ]; then
+  echo "Dry run: release prerequisites and signing environment are available"
+  ./scripts/bundle-node-runtime.sh "${APP_PATH}" --dry-run
+  echo "Dry run: would archive a universal Release app, sign it, create ${DMG_PATH}, notarize it, and staple the ticket"
+  exit 0
+fi
 
 echo "==> Cleaning..."
 rm -rf "${BUILD_DIR}"
@@ -43,6 +89,8 @@ xcodebuild archive \
   -destination "generic/platform=macOS" \
   SKIP_INSTALL=NO \
   SWIFT_VERIFY_EMITTED_MODULE_INTERFACE=NO \
+  ONLY_ACTIVE_ARCH=NO \
+  ARCHS="arm64 x86_64" \
   CODE_SIGN_STYLE=Automatic \
   DEVELOPMENT_TEAM="${TEAM_ID}" \
   ENABLE_HARDENED_RUNTIME=YES
@@ -62,14 +110,8 @@ rm -rf "${APP_PATH}"
 cp -R "${APP_IN_ARCHIVE}" "${APP_PATH}"
 
 echo "==> Bundling Node.js runtime..."
-NODE_VERSION="20.19.0"
-NODE_TMP="$(mktemp -d)"
-curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-darwin-arm64.tar.gz" \
-  | tar -xz -C "${NODE_TMP}" --strip-components=2 "node-v${NODE_VERSION}-darwin-arm64/bin/node"
-cp "${NODE_TMP}/node" "${APP_PATH}/Contents/Resources/node"
-chmod +x "${APP_PATH}/Contents/Resources/node"
-rm -rf "${NODE_TMP}"
-echo "   Bundled node v${NODE_VERSION} ($(du -sh "${APP_PATH}/Contents/Resources/node" | cut -f1))"
+./scripts/bundle-node-runtime.sh "${APP_PATH}"
+echo "   Bundled node ($(du -sh "${APP_PATH}/Contents/Resources/node" | cut -f1))"
 
 echo "==> Re-signing app (required after injecting node binary)..."
 # Sign the bundled node binary with JIT entitlements (V8 requires executable memory)
@@ -84,6 +126,8 @@ codesign --sign "${SIGNING_IDENTITY}" --force --deep --options runtime \
 
 echo "==> Verifying signature..."
 codesign --verify --deep --strict --verbose=2 "${APP_PATH}"
+echo "==> Verifying universal binaries..."
+./scripts/verify-universal-build.sh "${APP_PATH}" --skip-gatekeeper
 
 echo "==> Preparing DMG contents..."
 mkdir -p "${DMG_STAGING_DIR}"

--- a/scripts/build-dmg.sh
+++ b/scripts/build-dmg.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
-# Usage: ./scripts/build-dmg.sh
+# Usage: ./scripts/build-dmg.sh [--dry-run]
 # Creates a local (unsigned) install-style DMG in build/ for development/testing.
 
 set -euo pipefail
 
+DRY_RUN=0
 APP_NAME="SuperIsland"
 SCHEME="${APP_NAME}"
 BUILD_DIR="build"
@@ -11,6 +12,41 @@ DERIVED_DATA="${BUILD_DIR}/DerivedData"
 APP_PATH="${BUILD_DIR}/${APP_NAME}.app"
 DMG_PATH="${BUILD_DIR}/${APP_NAME}.dmg"
 DMG_STAGING_DIR="${BUILD_DIR}/dmg-root"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=1
+      ;;
+    -h|--help)
+      echo "Usage: $0 [--dry-run]"
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unexpected argument: $1"
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "ERROR: required command not found: $1"
+    exit 1
+  fi
+}
+
+for command_name in xcodegen xcodebuild hdiutil lipo security codesign; do
+  require_command "${command_name}"
+done
+
+if [ "${DRY_RUN}" = "1" ]; then
+  echo "Dry run: local DMG build prerequisites are available"
+  ./scripts/bundle-node-runtime.sh "${APP_PATH}" --dry-run
+  echo "Dry run: would build a universal Release app and create ${DMG_PATH}"
+  exit 0
+fi
 
 echo "==> Cleaning build directory..."
 rm -rf "${BUILD_DIR}"
@@ -25,8 +61,9 @@ xcodebuild build \
   -scheme "${SCHEME}" \
   -configuration Release \
   -derivedDataPath "${DERIVED_DATA}" \
-  -destination "platform=macOS,arch=arm64" \
-  ONLY_ACTIVE_ARCH=NO
+  -destination "generic/platform=macOS" \
+  ONLY_ACTIVE_ARCH=NO \
+  ARCHS="arm64 x86_64"
 
 echo "==> Copying app bundle..."
 BUILT_APP=$(find "${DERIVED_DATA}" -name "${APP_NAME}.app" -type d | head -1)
@@ -37,14 +74,8 @@ fi
 cp -R "${BUILT_APP}" "${APP_PATH}"
 
 echo "==> Bundling Node.js runtime..."
-NODE_VERSION="20.19.0"
-NODE_TMP="$(mktemp -d)"
-curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-darwin-arm64.tar.gz" \
-  | tar -xz -C "${NODE_TMP}" --strip-components=2 "node-v${NODE_VERSION}-darwin-arm64/bin/node"
-cp "${NODE_TMP}/node" "${APP_PATH}/Contents/Resources/node"
-chmod +x "${APP_PATH}/Contents/Resources/node"
-rm -rf "${NODE_TMP}"
-echo "   Bundled node v${NODE_VERSION} ($(du -sh "${APP_PATH}/Contents/Resources/node" | cut -f1))"
+./scripts/bundle-node-runtime.sh "${APP_PATH}"
+echo "   Bundled node ($(du -sh "${APP_PATH}/Contents/Resources/node" | cut -f1))"
 
 echo "==> Code signing for local testing..."
 # An unsigned app can't register with TCC (Calendar, Location, etc. won't appear in System Settings).
@@ -61,6 +92,9 @@ if [ -n "${CERT}" ]; then
 else
   echo "   Warning: no signing certificate found — TCC permissions (Calendar, etc.) won't register."
 fi
+
+echo "==> Verifying universal binaries..."
+./scripts/verify-universal-build.sh "${APP_PATH}" --skip-signature
 
 echo "==> Preparing DMG contents..."
 mkdir -p "${DMG_STAGING_DIR}"

--- a/scripts/bundle-node-runtime.sh
+++ b/scripts/bundle-node-runtime.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# Usage: ./scripts/bundle-node-runtime.sh path/to/SuperIsland.app [--dry-run]
+
+set -euo pipefail
+
+APP_PATH=""
+DRY_RUN=0
+NODE_VERSION="${NODE_VERSION:-20.19.0}"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=1
+      ;;
+    -h|--help)
+      echo "Usage: $0 path/to/SuperIsland.app [--dry-run]"
+      exit 0
+      ;;
+    *)
+      if [ -z "${APP_PATH}" ]; then
+        APP_PATH="$1"
+      else
+        echo "ERROR: unexpected argument: $1"
+        exit 1
+      fi
+      ;;
+  esac
+  shift
+done
+
+if [ -z "${APP_PATH}" ]; then
+  echo "ERROR: missing app path"
+  echo "Usage: $0 path/to/SuperIsland.app [--dry-run]"
+  exit 1
+fi
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "ERROR: required command not found: $1"
+    exit 1
+  fi
+}
+
+for command_name in curl tar lipo mktemp; do
+  require_command "${command_name}"
+done
+
+NODE_DEST="${APP_PATH}/Contents/Resources/node"
+
+if [ "${DRY_RUN}" = "1" ]; then
+  echo "Dry run: would download Node.js ${NODE_VERSION} for darwin-arm64 and darwin-x64"
+  echo "Dry run: would create universal runtime at ${NODE_DEST}"
+  exit 0
+fi
+
+if [ ! -d "${APP_PATH}/Contents/Resources" ]; then
+  echo "ERROR: app resources directory not found: ${APP_PATH}/Contents/Resources"
+  exit 1
+fi
+
+NODE_TMP="$(mktemp -d)"
+cleanup() {
+  rm -rf "${NODE_TMP}"
+}
+trap cleanup EXIT
+
+nodes=()
+for node_arch in arm64 x64; do
+  arch_dir="${NODE_TMP}/${node_arch}"
+  archive="${NODE_TMP}/node-${node_arch}.tar.gz"
+  mkdir -p "${arch_dir}"
+
+  echo "   Downloading node-v${NODE_VERSION}-darwin-${node_arch}..."
+  curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-darwin-${node_arch}.tar.gz" \
+    -o "${archive}"
+  tar -xzf "${archive}" \
+    -C "${arch_dir}" \
+    --strip-components=2 \
+    "node-v${NODE_VERSION}-darwin-${node_arch}/bin/node"
+  nodes+=("${arch_dir}/node")
+done
+
+lipo -create "${nodes[@]}" -output "${NODE_DEST}"
+chmod +x "${NODE_DEST}"
+lipo -info "${NODE_DEST}"

--- a/scripts/verify-universal-build.sh
+++ b/scripts/verify-universal-build.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# Usage: ./scripts/verify-universal-build.sh path/to/SuperIsland.app [--skip-signature] [--skip-gatekeeper]
+
+set -euo pipefail
+
+APP_PATH=""
+SKIP_SIGNATURE=0
+SKIP_GATEKEEPER=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --skip-signature)
+      SKIP_SIGNATURE=1
+      SKIP_GATEKEEPER=1
+      ;;
+    --skip-gatekeeper)
+      SKIP_GATEKEEPER=1
+      ;;
+    -h|--help)
+      echo "Usage: $0 path/to/SuperIsland.app [--skip-signature] [--skip-gatekeeper]"
+      exit 0
+      ;;
+    *)
+      if [ -z "${APP_PATH}" ]; then
+        APP_PATH="$1"
+      else
+        echo "ERROR: unexpected argument: $1"
+        exit 1
+      fi
+      ;;
+  esac
+  shift
+done
+
+if [ -z "${APP_PATH}" ]; then
+  echo "ERROR: missing app path"
+  echo "Usage: $0 path/to/SuperIsland.app [--skip-signature] [--skip-gatekeeper]"
+  exit 1
+fi
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "ERROR: required command not found: $1"
+    exit 1
+  fi
+}
+
+for command_name in lipo codesign spctl; do
+  require_command "${command_name}"
+done
+
+if [ ! -d "${APP_PATH}" ]; then
+  echo "ERROR: app bundle not found: ${APP_PATH}"
+  exit 1
+fi
+
+APP_BINARY="${APP_PATH}/Contents/MacOS/SuperIsland"
+NODE_BINARY="${APP_PATH}/Contents/Resources/node"
+
+check_universal_binary() {
+  local binary_path="$1"
+  local label="$2"
+
+  if [ ! -f "${binary_path}" ]; then
+    echo "ERROR: ${label} binary not found: ${binary_path}"
+    exit 1
+  fi
+
+  local info
+  info="$(lipo -info "${binary_path}")"
+  echo "${info}"
+
+  case "${info}" in
+    *arm64*x86_64*|*x86_64*arm64*)
+      ;;
+    *)
+      echo "ERROR: ${label} is not universal arm64 + x86_64"
+      exit 1
+      ;;
+  esac
+}
+
+check_universal_binary "${APP_BINARY}" "SuperIsland"
+
+if [ -f "${NODE_BINARY}" ]; then
+  check_universal_binary "${NODE_BINARY}" "Bundled node"
+fi
+
+if [ "${SKIP_SIGNATURE}" = "0" ]; then
+  codesign --verify --deep --strict --verbose=2 "${APP_PATH}"
+else
+  echo "Skipping codesign verification"
+fi
+
+if [ "${SKIP_GATEKEEPER}" = "0" ]; then
+  spctl --assess --type execute --verbose "${APP_PATH}"
+else
+  echo "Skipping Gatekeeper assessment"
+fi
+
+echo "Universal build verification passed: ${APP_PATH}"


### PR DESCRIPTION
Summary:
- Adds build verification for universal macOS releases.
- Adds a Homebrew Cask packaging template and release checklist.
- Improves signing, notarization, dry-run, and missing-prerequisite handling in release scripts.
- Keeps local unsigned builds separate from signed release builds.
- Addresses #60.

Validation:
- `bash -n` passed for release and packaging scripts.
- `ruby -c packaging/homebrew/superisland.rb` passed.
- `git diff --check` passed.
- `./scripts/bundle-node-runtime.sh build/SuperIsland.app --dry-run` passed.
- `./scripts/verify-universal-build.sh --help` passed.
- `./scripts/build-dmg.sh --dry-run` failed clearly because `xcodegen` is unavailable locally.
- `./scripts/build-and-release.sh --dry-run` failed clearly because `xcodegen` is unavailable locally.
- `xcodebuild -version` reported Xcode 26.5.
- `xcodegen generate` could not run because `xcodegen` is unavailable locally.

Screenshots needed:
- None. This PR changes release scripts and documentation only.

Risk notes:
- Universal runtime bundling downloads two Node.js archives instead of one, so release builds depend on both upstream archive URLs.
- Maintainers should run the full release script on a machine with XcodeGen, signing credentials, and notarization credentials before publishing.
- The Homebrew Cask keeps a placeholder SHA256 until a real release DMG is uploaded.