### PR TITLE
Add notification permissions and configurable notification sources

### DIFF
--- a/ExtensionHost/ExtensionJSRuntime.swift
+++ b/ExtensionHost/ExtensionJSRuntime.swift
@@ -1,7 +1,7 @@
 import Foundation
 import JavaScriptCore
 import AppKit
-import UserNotifications
+@preconcurrency import UserNotifications
 
 final class ExtensionJSRuntime {
     enum RuntimeError: LocalizedError {
@@ -316,20 +316,22 @@ final class ExtensionJSRuntime {
             let shouldShowSystemNotification = options.forProperty("systemNotification")?.isBoolean == true
                 ? (options.forProperty("systemNotification")?.toBool() ?? true)
                 : true
-            self.sendNotification(
-                title: title,
-                body: body,
-                sound: sound,
-                appName: appName,
-                bundleIdentifier: bundleIdentifier,
-                senderName: senderName,
-                previewText: previewText,
-                avatarURL: avatarURL,
-                appIconURL: appIconURL,
-                sourceID: sourceID,
-                tapAction: tapAction,
-                shouldShowSystemNotification: shouldShowSystemNotification
-            )
+            Task { @MainActor [weak self] in
+                self?.sendNotification(
+                    title: title,
+                    body: body,
+                    sound: sound,
+                    appName: appName,
+                    bundleIdentifier: bundleIdentifier,
+                    senderName: senderName,
+                    previewText: previewText,
+                    avatarURL: avatarURL,
+                    appIconURL: appIconURL,
+                    sourceID: sourceID,
+                    tapAction: tapAction,
+                    shouldShowSystemNotification: shouldShowSystemNotification
+                )
+            }
         }
 
         notifications.setObject(send, forKeyedSubscript: "send" as NSString)
@@ -992,6 +994,7 @@ final class ExtensionJSRuntime {
         ], in: context)
     }
 
+    @MainActor
     private func sendNotification(
         title: String,
         body: String,
@@ -1006,10 +1009,10 @@ final class ExtensionJSRuntime {
         tapAction: NotificationTapAction?,
         shouldShowSystemNotification: Bool
     ) {
-        let center = UNUserNotificationCenter.current()
-        center.requestAuthorization(options: [.alert, .sound]) { _, _ in }
+        let extensionsSourceEnabled = AppState.shared.notificationsEnabled
+            && AppState.shared.isNotificationSourceEnabled(.extensions)
 
-        if manifest.capabilities.notificationFeed {
+        if manifest.capabilities.notificationFeed, extensionsSourceEnabled {
             let resolvedAppName = appName ?? manifest.name
             let resolvedBundleIdentifier = bundleIdentifier ?? extensionID
             let resolvedSenderName = senderName ?? (title.isEmpty ? nil : title)
@@ -1038,7 +1041,8 @@ final class ExtensionJSRuntime {
             }
         }
 
-        if shouldShowSystemNotification {
+        if shouldShowSystemNotification, extensionsSourceEnabled {
+            let center = UNUserNotificationCenter.current()
             let content = UNMutableNotificationContent()
             content.title = title
             content.body = body
@@ -1049,7 +1053,21 @@ final class ExtensionJSRuntime {
                 content: content,
                 trigger: UNTimeIntervalNotificationTrigger(timeInterval: 0.1, repeats: false)
             )
-            center.add(request)
+            center.getNotificationSettings { settings in
+                switch settings.authorizationStatus {
+                case .authorized, .provisional, .ephemeral:
+                    center.add(request)
+                case .notDetermined:
+                    center.requestAuthorization(options: [.alert, .sound]) { granted, _ in
+                        guard granted else { return }
+                        center.add(request)
+                    }
+                case .denied:
+                    break
+                @unknown default:
+                    break
+                }
+            }
         }
     }
 
@@ -1058,13 +1076,14 @@ final class ExtensionJSRuntime {
         guard let latest = NotificationManager.shared.latestNotification else {
             return nil
         }
-        return notificationPayload(from: latest)
+        return notificationPayload(from: NotificationManager.shared.displayNotification(latest))
     }
 
     @MainActor
     private func recentNotificationPayloads(limit: Int) -> [[String: Any]] {
         NotificationManager.shared.recentNotifications
             .prefix(limit)
+            .map { NotificationManager.shared.displayNotification($0) }
             .map(notificationPayload(from:))
     }
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ scripts/            Build & release scripts
 
 Extensions are JavaScript packages that run inside a sandboxed JavaScriptCore context. Read the full guide at [dynamicisland.app/docs](https://dynamicisland.app/docs) or in [EXTENSIONS.md](EXTENSIONS.md).
 
+## Notifications
+
+The Notifications module supports source-level controls for SuperIsland extensions, the bundled WhatsApp integration, and compatible public app broadcasts. See [docs/NOTIFICATIONS.md](docs/NOTIFICATIONS.md).
+
 ---
 
 ## Contributing

--- a/SuperIsland/App/AppDelegate.swift
+++ b/SuperIsland/App/AppDelegate.swift
@@ -112,11 +112,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             _ = WeatherManager.shared
         }
         if state.notificationsEnabled {
-            Task { @MainActor in
-                if await PermissionsManager.shared.notificationsGranted() {
-                    _ = NotificationManager.shared
-                }
-            }
+            _ = NotificationManager.shared
         }
 
         let extensions = ExtensionManager.shared

--- a/SuperIsland/App/AppState.swift
+++ b/SuperIsland/App/AppState.swift
@@ -256,6 +256,9 @@ final class AppState: ObservableObject {
     @AppStorage("module.weather.enabled") var weatherEnabled = true
     @AppStorage("module.weather.temperatureUnit") var temperatureUnit: TemperatureUnit = .celsius
     @AppStorage("module.notifications.enabled") var notificationsEnabled = true
+    @AppStorage("module.notifications.showPreviews") var notificationPreviewsEnabled = true
+    @AppStorage("module.notifications.maxRetainedItems") var notificationMaxRetainedItems: Double = 10
+    @AppStorage("module.notifications.enabledSources") private var notificationEnabledSourcesRaw = NotificationFeedSource.defaultEnabledRawValue
     @AppStorage("module.teleprompter.enabled") var teleprompterEnabled = false
     @AppStorage("module.shelf.autoOpenOnDrop") var shelfAutoOpenOnDrop = true
     @AppStorage("module.shelf.defaultToShelf") var shelfDefaultToShelf = false
@@ -305,6 +308,35 @@ final class AppState: ObservableObject {
             extraBounce: bounceAmount,
             blendDuration: 0.125
         )
+    }
+
+    var enabledNotificationSourceIDs: Set<String> {
+        get {
+            Set(notificationEnabledSourcesRaw
+                .split(separator: ",")
+                .map { String($0) }
+                .filter { !$0.isEmpty })
+        }
+        set {
+            notificationEnabledSourcesRaw = NotificationFeedSource.allCases
+                .map(\.rawValue)
+                .filter { newValue.contains($0) }
+                .joined(separator: ",")
+        }
+    }
+
+    func isNotificationSourceEnabled(_ source: NotificationFeedSource) -> Bool {
+        enabledNotificationSourceIDs.contains(source.rawValue)
+    }
+
+    func setNotificationSource(_ source: NotificationFeedSource, enabled: Bool) {
+        var enabledSources = enabledNotificationSourceIDs
+        if enabled {
+            enabledSources.insert(source.rawValue)
+        } else {
+            enabledSources.remove(source.rawValue)
+        }
+        enabledNotificationSourceIDs = enabledSources
     }
 
     // MARK: - State Transitions

--- a/SuperIsland/Modules/Notifications/NotificationCompactView.swift
+++ b/SuperIsland/Modules/Notifications/NotificationCompactView.swift
@@ -6,7 +6,8 @@ struct NotificationCompactView: View {
 
     var body: some View {
         HStack(spacing: 6) {
-            if let notif = manager.latestNotification {
+            if let latestNotification = manager.latestNotification {
+                let notif = manager.displayNotification(latestNotification)
                 notificationLeadingView(notif, size: 14)
 
                 Text(headline(for: notif))

--- a/SuperIsland/Modules/Notifications/NotificationExpandedView.swift
+++ b/SuperIsland/Modules/Notifications/NotificationExpandedView.swift
@@ -40,7 +40,7 @@ struct NotificationExpandedView: View {
                 .foregroundColor(.white.opacity(0.5))
 
             if appState.currentState == .fullExpanded {
-                Text("Notifications from apps will appear here")
+                Text("Supported sources will appear here")
                     .font(.system(size: 11))
                     .foregroundColor(.white.opacity(0.3))
             }
@@ -93,11 +93,11 @@ struct NotificationExpandedView: View {
 
     private var allNotifications: [IslandNotification] {
         if !manager.recentNotifications.isEmpty {
-            return manager.recentNotifications
+            return manager.recentNotifications.map { manager.displayNotification($0) }
         }
 
         if let latestNotification = manager.latestNotification {
-            return [latestNotification]
+            return [manager.displayNotification(latestNotification)]
         }
 
         return []

--- a/SuperIsland/Modules/Notifications/NotificationManager.swift
+++ b/SuperIsland/Modules/Notifications/NotificationManager.swift
@@ -32,6 +32,37 @@ struct IslandNotification: Identifiable {
     let tapAction: NotificationTapAction?
 }
 
+enum NotificationFeedSource: String, CaseIterable, Identifiable {
+    case extensions
+    case whatsApp
+    case compatibleApps
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .extensions: return "Extension notifications"
+        case .whatsApp: return "WhatsApp"
+        case .compatibleApps: return "Compatible app broadcasts"
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .extensions:
+            return "Notifications sent by installed SuperIsland extensions."
+        case .whatsApp:
+            return "Notifications from the bundled WhatsApp integration."
+        case .compatibleApps:
+            return "Notification-like events from apps that publish public distributed notifications."
+        }
+    }
+
+    static var defaultEnabledRawValue: String {
+        allCases.map(\.rawValue).joined(separator: ",")
+    }
+}
+
 @MainActor
 final class NotificationManager: ObservableObject {
     private static let accessibilityPromptedDefaultsKey = "notifications.accessibilityPrompted"
@@ -58,8 +89,8 @@ final class NotificationManager: ObservableObject {
     @Published var latestNotification: IslandNotification?
     @Published var recentNotifications: [IslandNotification] = []
     @Published var hasPermission: Bool = false
+    @Published var authorizationStatus: UNAuthorizationStatus = .notDetermined
 
-    private let maxNotifications = 10
     private let logMonitorQueue = DispatchQueue(label: "superisland.whatsapp-log-monitor", qos: .utility)
     private let deliveredMonitorQueue = DispatchQueue(label: "superisland.notifications-delivered-monitor", qos: .utility)
     private var whatsappLogMonitorTimer: DispatchSourceTimer?
@@ -86,7 +117,8 @@ final class NotificationManager: ObservableObject {
     func checkPermission() {
         UNUserNotificationCenter.current().getNotificationSettings { [weak self] settings in
             DispatchQueue.main.async {
-                self?.hasPermission = settings.authorizationStatus == .authorized
+                self?.authorizationStatus = settings.authorizationStatus
+                self?.hasPermission = Self.isAuthorized(settings.authorizationStatus)
             }
         }
     }
@@ -98,10 +130,28 @@ final class NotificationManager: ObservableObject {
                     .requestAuthorization(options: [.alert, .sound, .badge])
                 await MainActor.run {
                     hasPermission = granted
+                    checkPermission()
                 }
             } catch {
-                print("Notification permission error: \(error)")
+                await MainActor.run {
+                    checkPermission()
+                }
             }
+        }
+    }
+
+    func openNotificationSettings() {
+        PermissionsManager.shared.openNotificationsSettings()
+    }
+
+    private static func isAuthorized(_ status: UNAuthorizationStatus) -> Bool {
+        switch status {
+        case .authorized, .provisional, .ephemeral:
+            return true
+        case .notDetermined, .denied:
+            return false
+        @unknown default:
+            return false
         }
     }
 
@@ -1042,11 +1092,18 @@ final class NotificationManager: ObservableObject {
 
     func addNotification(_ notification: IslandNotification) {
         let normalized = normalizedNotification(notification)
+        guard AppState.shared.notificationsEnabled, isNotificationAllowed(normalized) else { return }
+
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
-            self.recentNotifications = self.recentNotifications.map { self.normalizedNotification($0) }
+            self.recentNotifications = self.recentNotifications
+                .map { self.normalizedNotification($0) }
+                .filter { self.isNotificationAllowed($0) }
             if let latest = self.latestNotification {
-                self.latestNotification = self.normalizedNotification(latest)
+                let normalizedLatest = self.normalizedNotification(latest)
+                self.latestNotification = self.isNotificationAllowed(normalizedLatest)
+                    ? normalizedLatest
+                    : nil
             }
 
             guard !self.shouldSuppressIncomingNotification(normalized) else {
@@ -1067,13 +1124,30 @@ final class NotificationManager: ObservableObject {
             self.latestNotification = mergedNotification
             self.recentNotifications.removeAll { $0.sourceID == mergedNotification.sourceID }
             self.recentNotifications.insert(mergedNotification, at: 0)
-            if self.recentNotifications.count > self.maxNotifications {
-                self.recentNotifications.removeLast()
+            if self.recentNotifications.count > self.maxRetainedNotifications {
+                self.recentNotifications.removeLast(self.recentNotifications.count - self.maxRetainedNotifications)
             }
             AppState.shared.showHUD(
                 module: .notifications,
                 autoDismissDelay: Constants.notificationDisplayDuration
             )
+        }
+    }
+
+    func applyFeedPreferences() {
+        recentNotifications = recentNotifications
+            .map { normalizedNotification($0) }
+            .filter { isNotificationAllowed($0) }
+        if let latestNotification {
+            let normalizedLatest = normalizedNotification(latestNotification)
+            self.latestNotification = isNotificationAllowed(normalizedLatest)
+                ? normalizedLatest
+                : recentNotifications.first
+        } else {
+            latestNotification = recentNotifications.first
+        }
+        if recentNotifications.count > maxRetainedNotifications {
+            recentNotifications.removeLast(recentNotifications.count - maxRetainedNotifications)
         }
     }
 
@@ -1137,6 +1211,45 @@ final class NotificationManager: ObservableObject {
             value: tapAction.payload,
             presentation: tapAction.presentation,
             returnModule: .builtIn(.notifications)
+        )
+    }
+
+    private var maxRetainedNotifications: Int {
+        min(50, max(1, Int(AppState.shared.notificationMaxRetainedItems.rounded())))
+    }
+
+    private func isNotificationAllowed(_ notification: IslandNotification) -> Bool {
+        AppState.shared.isNotificationSourceEnabled(feedSource(for: notification))
+    }
+
+    private func feedSource(for notification: IslandNotification) -> NotificationFeedSource {
+        if isWhatsAppNotification(notification) {
+            return .whatsApp
+        }
+
+        if notification.sourceID.hasPrefix("extension:") || notification.tapAction != nil {
+            return .extensions
+        }
+
+        return .compatibleApps
+    }
+
+    func displayNotification(_ notification: IslandNotification) -> IslandNotification {
+        guard !AppState.shared.notificationPreviewsEnabled else { return notification }
+
+        return IslandNotification(
+            sourceID: notification.sourceID,
+            appName: notification.appName,
+            bundleIdentifier: notification.bundleIdentifier,
+            appIcon: notification.appIcon,
+            appIconURL: notification.appIconURL,
+            title: notification.appName,
+            body: "Preview hidden",
+            senderName: nil,
+            previewText: nil,
+            avatarURL: nil,
+            timestamp: notification.timestamp,
+            tapAction: notification.tapAction
         )
     }
 

--- a/SuperIsland/Settings/ModuleSettingsView.swift
+++ b/SuperIsland/Settings/ModuleSettingsView.swift
@@ -1,7 +1,10 @@
+import AppKit
 import SwiftUI
+import UserNotifications
 
 struct ModuleSettingsView: View {
     @EnvironmentObject var appState: AppState
+    @ObservedObject private var notificationManager = NotificationManager.shared
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -44,7 +47,27 @@ struct ModuleSettingsView: View {
                 .padding(.horizontal, 16)
                 .padding(.vertical, 11)
                 SettingRowDivider()
-                SettingToggleRow(title: "Notifications", isOn: $appState.notificationsEnabled)
+                SettingToggleRow(title: "Notifications", isOn: notificationsEnabledBinding)
+                if appState.notificationsEnabled {
+                    SettingRowDivider()
+                    notificationPermissionRow
+                    SettingRowDivider()
+                    SettingToggleRow(
+                        title: "Show previews",
+                        description: "Display sender and message text when available.",
+                        isOn: notificationPreviewsBinding
+                    )
+                    SettingRowDivider()
+                    notificationRetentionRow
+                    ForEach(NotificationFeedSource.allCases) { source in
+                        SettingRowDivider()
+                        SettingToggleRow(
+                            title: source.title,
+                            description: source.description,
+                            isOn: notificationSourceBinding(for: source)
+                        )
+                    }
+                }
             }
 
             SettingSectionLabel(title: "Productivity")
@@ -65,5 +88,130 @@ struct ModuleSettingsView: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .topLeading)
+        .onAppear { notificationManager.checkPermission() }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            notificationManager.checkPermission()
+        }
+    }
+
+    private var notificationPermissionRow: some View {
+        HStack(alignment: .top, spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Permission")
+                    .font(.system(size: 13))
+                Text(notificationPermissionDescription)
+                    .font(.system(size: 11))
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 12)
+            Button(notificationPermissionButtonTitle) {
+                handleNotificationPermissionAction()
+            }
+            .font(.system(size: 12))
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 11)
+    }
+
+    private var notificationRetentionRow: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Retained items")
+                    .font(.system(size: 13))
+                Text("How many feed items stay available in the island.")
+                    .font(.system(size: 11))
+                    .foregroundColor(.secondary)
+            }
+            Spacer(minLength: 12)
+            StepperField(
+                value: notificationMaxRetainedBinding,
+                step: 1,
+                range: 1...50
+            ) { "\(Int($0))" }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 11)
+    }
+
+    private var notificationPermissionDescription: String {
+        switch notificationManager.authorizationStatus {
+        case .authorized:
+            return "Allowed. SuperIsland can send its own notifications and extension alerts."
+        case .denied:
+            return "Denied. Open System Settings to allow SuperIsland notifications."
+        case .notDetermined:
+            return "Not requested. Allow this when you want SuperIsland or extensions to send macOS notifications."
+        case .provisional, .ephemeral:
+            return "Allowed with limited delivery."
+        @unknown default:
+            return "Unknown. Check macOS notification settings."
+        }
+    }
+
+    private var notificationPermissionButtonTitle: String {
+        switch notificationManager.authorizationStatus {
+        case .notDetermined:
+            return "Request"
+        default:
+            return "Open Settings"
+        }
+    }
+
+    private var notificationsEnabledBinding: Binding<Bool> {
+        Binding(
+            get: { appState.notificationsEnabled },
+            set: { newValue in
+                appState.notificationsEnabled = newValue
+                guard newValue else {
+                    NotificationManager.shared.clearAll()
+                    return
+                }
+
+                NotificationManager.shared.checkPermission()
+                if NotificationManager.shared.authorizationStatus == .notDetermined {
+                    NotificationManager.shared.requestPermission()
+                }
+            }
+        )
+    }
+
+    private var notificationPreviewsBinding: Binding<Bool> {
+        Binding(
+            get: { appState.notificationPreviewsEnabled },
+            set: { newValue in
+                appState.notificationPreviewsEnabled = newValue
+                NotificationManager.shared.applyFeedPreferences()
+            }
+        )
+    }
+
+    private var notificationMaxRetainedBinding: Binding<Double> {
+        Binding(
+            get: { appState.notificationMaxRetainedItems },
+            set: { newValue in
+                appState.notificationMaxRetainedItems = newValue
+                NotificationManager.shared.applyFeedPreferences()
+            }
+        )
+    }
+
+    private func notificationSourceBinding(for source: NotificationFeedSource) -> Binding<Bool> {
+        Binding(
+            get: { appState.isNotificationSourceEnabled(source) },
+            set: { newValue in
+                appState.setNotificationSource(source, enabled: newValue)
+                NotificationManager.shared.applyFeedPreferences()
+            }
+        )
+    }
+
+    private func handleNotificationPermissionAction() {
+        switch notificationManager.authorizationStatus {
+        case .notDetermined:
+            notificationManager.requestPermission()
+        default:
+            notificationManager.openNotificationSettings()
+        }
     }
 }

--- a/SuperIsland/Utilities/Permissions.swift
+++ b/SuperIsland/Utilities/Permissions.swift
@@ -32,7 +32,7 @@ enum PermissionType: CaseIterable {
         case .accessibility: return "Needed for gesture detection and system event monitoring"
         case .screenRecording: return "Lets SuperIsland appear properly in screen recordings"
         case .calendar: return "Show upcoming events in the Super Island"
-        case .notifications: return "Mirror notifications in the Super Island"
+        case .notifications: return "Show supported notification sources in the Super Island"
         case .microphone: return "Audio visualization for the spectrogram"
         case .location: return "Provide weather information for your location"
         case .bluetooth: return "Show connected device notifications"
@@ -183,14 +183,21 @@ final class PermissionsManager {
     func notificationsGranted() async -> Bool {
         await withCheckedContinuation { continuation in
             UNUserNotificationCenter.current().getNotificationSettings { settings in
-                continuation.resume(returning: settings.authorizationStatus == .authorized)
+                switch settings.authorizationStatus {
+                case .authorized, .provisional, .ephemeral:
+                    continuation.resume(returning: true)
+                case .notDetermined, .denied:
+                    continuation.resume(returning: false)
+                @unknown default:
+                    continuation.resume(returning: false)
+                }
             }
         }
     }
 
     func requestNotificationAccess() async -> Bool {
         do {
-            return try await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound])
+            return try await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge])
         } catch {
             return false
         }

--- a/docs/NOTIFICATIONS.md
+++ b/docs/NOTIFICATIONS.md
@@ -1,0 +1,21 @@
+# Notifications
+
+SuperIsland can show notification-like events from supported sources. macOS does not provide a public API for arbitrary apps to read every item from Notification Center, so the module should not be described as full system-wide notification mirroring.
+
+## Supported sources
+
+- Extension notifications from installed SuperIsland extensions.
+- WhatsApp notifications from the bundled WhatsApp integration.
+- Compatible app broadcasts from apps that publish public distributed notifications.
+
+Settings -> Modules -> Notifications lets users enable or disable each supported source, hide previews, and choose how many feed items are retained.
+
+## macOS notification permission
+
+SuperIsland requests notification permission when the Notifications module or an extension needs to send macOS notifications. This permission allows SuperIsland to deliver its own notifications. It does not grant private access to other apps' Notification Center contents.
+
+If permission is denied, use Settings -> Modules -> Notifications -> Permission to open System Settings.
+
+## Unsupported behavior
+
+Installed-app selection is only safe when those apps expose a supported public source. Until a provider exists for a specific app, SuperIsland should show source-level controls instead of claiming it can mirror every app installed on the Mac.


### PR DESCRIPTION
Summary:
- Adds notification authorization status, request handling, and a Settings action for System Settings.
- Adds configurable source filtering for supported notification sources.
- Adds preview hiding and feed retention controls.
- Makes notification behavior match public macOS API limits instead of claiming full system-wide mirroring.
- Ensures extension notification APIs respect the Notifications module and extension source setting.
- Addresses #70.

Issue relevance check:
- Verified #70 is about SuperIsland's current Notifications module and Settings UI.
- Checked `NotificationManager.swift`, `ModuleSettingsView.swift`, extension notification APIs, and the current docs wording.
- Implemented only the public-API-safe scope for supported sources.

Validation:
- `git diff --check` passed.
- Direct Swift typecheck of app sources passed with the package-backed analytics source excluded because package resolution depends on generated project setup.
- `xcodebuild -version` reported Xcode 26.5.
- `xcodegen generate` could not run because `xcodegen` is unavailable locally.
- Full `xcodebuild` could not run because the project file is generated and is not present without XcodeGen.

Screenshots needed:
- Settings -> Modules -> Notifications permission row.
- Settings -> Modules -> Notifications supported source toggles.

Risk notes:
- This does not implement arbitrary installed-app notification mirroring because macOS does not expose that through public APIs.
- Users will see supported source controls instead of per-installed-app controls until specific providers exist.
- Manual permission testing is still needed on a fresh install or reset notification permission state.