### PR TITLE
Add calendar source selection and duplicate event filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ scripts/            Build & release scripts
 
 Extensions are JavaScript packages that run inside a sandboxed JavaScriptCore context. Read the full guide at [dynamicisland.app/docs](https://dynamicisland.app/docs) or in [EXTENSIONS.md](EXTENSIONS.md).
 
+## Calendar
+
+The Calendar module supports account/source selection, holiday and birthday filters, duplicate collapse, and meeting-link actions. See [docs/CALENDAR.md](docs/CALENDAR.md).
+
 ---
 
 ## Contributing

--- a/SuperIsland/Modules/Calendar/CalendarExpandedView.swift
+++ b/SuperIsland/Modules/Calendar/CalendarExpandedView.swift
@@ -315,18 +315,28 @@ struct CalendarExpandedView: View {
 
             Spacer(minLength: 0)
 
-            if let url = manager.joinURL(for: event) {
-                Button { NSWorkspace.shared.open(url) } label: {
-                    Image(systemName: "video.fill")
-                        .font(.system(size: 9, weight: .bold))
-                        .foregroundColor(.white.opacity(0.88))
-                        .frame(width: 24, height: 24)
-                        .background(Color.white.opacity(0.08))
-                        .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+            HStack(spacing: 4) {
+                if let url = manager.joinURL(for: event) {
+                    Button { NSWorkspace.shared.open(url) } label: {
+                        eventActionIcon("video.fill")
+                    }
+                    .buttonStyle(.plain)
+                    .help("Open meeting link")
+
+                    Button { copy(url: url) } label: {
+                        eventActionIcon("doc.on.doc")
+                    }
+                    .buttonStyle(.plain)
+                    .help("Copy meeting link")
+                }
+
+                Button { manager.hideCalendar(for: event) } label: {
+                    eventActionIcon("eye.slash")
                 }
                 .buttonStyle(.plain)
-                .padding(.top, 4)
+                .help("Hide this calendar")
             }
+            .padding(.top, 4)
         }
         .padding(.vertical, 4)
         .padding(.horizontal, 6)
@@ -339,6 +349,20 @@ struct CalendarExpandedView: View {
     private func isEventActive(_ event: EKEvent) -> Bool {
         let now = Date()
         return !event.isAllDay && event.startDate <= now && event.endDate > now
+    }
+
+    private func eventActionIcon(_ name: String) -> some View {
+        Image(systemName: name)
+            .font(.system(size: 9, weight: .bold))
+            .foregroundColor(.white.opacity(0.88))
+            .frame(width: 24, height: 24)
+            .background(Color.white.opacity(0.08))
+            .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+    }
+
+    private func copy(url: URL) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(url.absoluteString, forType: .string)
     }
 
     // MARK: - Day Cell

--- a/SuperIsland/Modules/Calendar/CalendarManager.swift
+++ b/SuperIsland/Modules/Calendar/CalendarManager.swift
@@ -1,9 +1,25 @@
 import Foundation
 import EventKit
 import Combine
+import CoreGraphics
 
 private extension Int {
     var nonZero: Int? { self == 0 ? nil : self }
+}
+
+struct CalendarDisplayOption: Identifiable {
+    let id: String
+    let title: String
+    let sourceID: String
+    let sourceTitle: String
+    let color: CGColor
+    let type: EKCalendarType
+}
+
+struct CalendarSourceGroup: Identifiable {
+    let id: String
+    let title: String
+    let calendars: [CalendarDisplayOption]
 }
 
 @MainActor
@@ -13,17 +29,38 @@ final class CalendarManager: ObservableObject {
     @Published var todayEvents: [EKEvent] = []
     @Published var nextEvent: EKEvent?
     @Published var hasAccess: Bool = false
+    @Published var authorizationStatus: EKAuthorizationStatus = EKEventStore.authorizationStatus(for: .event)
     @Published var displayedMonthStart: Date = startOfMonth(for: Date()) {
         didSet { prefetchDatesWithEventsIfNeeded() }
     }
     @Published var selectedDate: Date = Date()
     @Published var selectedDateEvents: [EKEvent] = []
     @Published var upcomingWeekEvents: [(date: Date, events: [EKEvent])] = []
+    @Published var calendarSourceGroups: [CalendarSourceGroup] = []
+    @Published var hideBirthdays: Bool = UserDefaults.standard.bool(forKey: "calendar.hideBirthdays") {
+        didSet {
+            UserDefaults.standard.set(hideBirthdays, forKey: "calendar.hideBirthdays")
+            refreshEventsAfterPreferenceChange()
+        }
+    }
+    @Published var hideHolidays: Bool = UserDefaults.standard.bool(forKey: "calendar.hideHolidays") {
+        didSet {
+            UserDefaults.standard.set(hideHolidays, forKey: "calendar.hideHolidays")
+            refreshEventsAfterPreferenceChange()
+        }
+    }
+    @Published var collapseDuplicates: Bool = UserDefaults.standard.object(forKey: "calendar.collapseDuplicates") as? Bool ?? true {
+        didSet {
+            UserDefaults.standard.set(collapseDuplicates, forKey: "calendar.collapseDuplicates")
+            refreshEventsAfterPreferenceChange()
+        }
+    }
 
     private let store = EKEventStore()
     private var refreshTimer: Timer?
     private var preEventTimer: Timer?
     private let calendarQueue = DispatchQueue(label: "superisland.calendar", qos: .userInitiated)
+    private let enabledCalendarIDsKey = "calendar.enabledCalendarIDs"
     @Published var datesWithEvents: Set<Date> = []
 
     var preEventMinutes: Int {
@@ -31,11 +68,33 @@ final class CalendarManager: ObservableObject {
         set { UserDefaults.standard.set(newValue, forKey: "calendar.preEventMinutes") }
     }
 
+    var lookaheadDays: Int {
+        get { UserDefaults.standard.integer(forKey: "calendar.lookaheadDays").nonZero ?? 7 }
+        set {
+            UserDefaults.standard.set(max(1, min(30, newValue)), forKey: "calendar.lookaheadDays")
+            fetchUpcomingWeekEvents()
+        }
+    }
+
     private init() {
-        requestAccess()
+        refreshAccessStatus()
     }
 
     // MARK: - Access
+
+    func refreshAccessStatus() {
+        authorizationStatus = EKEventStore.authorizationStatus(for: .event)
+        hasAccess = Self.isAuthorized(authorizationStatus)
+        if hasAccess {
+            reloadCalendars()
+            fetchTodayEvents()
+            startRefreshTimer()
+            prefetchDatesWithEventsIfNeeded()
+        } else {
+            clearEvents()
+            stopRefreshTimer()
+        }
+    }
 
     func requestAccess() {
         Task {
@@ -43,16 +102,104 @@ final class CalendarManager: ObservableObject {
                 let granted = try await store.requestFullAccessToEvents()
                 await MainActor.run {
                     hasAccess = granted
+                    authorizationStatus = EKEventStore.authorizationStatus(for: .event)
                     if granted {
+                        reloadCalendars()
                         fetchTodayEvents()
                         startRefreshTimer()
                         prefetchDatesWithEventsIfNeeded()
                     }
                 }
             } catch {
+                await MainActor.run {
+                    authorizationStatus = EKEventStore.authorizationStatus(for: .event)
+                    hasAccess = Self.isAuthorized(authorizationStatus)
+                }
                 print("Calendar access error: \(error)")
             }
         }
+    }
+
+    func openCalendarSettings() {
+        PermissionsManager.shared.openCalendarSettings()
+    }
+
+    private static func isAuthorized(_ status: EKAuthorizationStatus) -> Bool {
+        switch status {
+        case .fullAccess, .authorized:
+            return true
+        default:
+            return false
+        }
+    }
+
+    // MARK: - Calendar Sources
+
+    var hasCustomCalendarSelection: Bool {
+        UserDefaults.standard.object(forKey: enabledCalendarIDsKey) != nil
+    }
+
+    var enabledCalendarIDs: Set<String> {
+        Set(UserDefaults.standard.stringArray(forKey: enabledCalendarIDsKey) ?? [])
+    }
+
+    func isCalendarEnabled(_ calendarID: String) -> Bool {
+        guard hasCustomCalendarSelection else { return true }
+        return enabledCalendarIDs.contains(calendarID)
+    }
+
+    func setCalendar(_ calendarID: String, enabled: Bool) {
+        var selectedIDs = hasCustomCalendarSelection ? enabledCalendarIDs : Set(allCalendarIDs)
+        if enabled {
+            selectedIDs.insert(calendarID)
+        } else {
+            selectedIDs.remove(calendarID)
+        }
+
+        UserDefaults.standard.set(allCalendarIDs.filter { selectedIDs.contains($0) }, forKey: enabledCalendarIDsKey)
+        refreshEventsAfterPreferenceChange()
+    }
+
+    func hideCalendar(for event: EKEvent) {
+        guard let calendar = event.calendar else { return }
+        setCalendar(calendar.calendarIdentifier, enabled: false)
+    }
+
+    func reloadCalendars() {
+        guard hasAccess else {
+            calendarSourceGroups = []
+            return
+        }
+
+        let grouped = Dictionary(grouping: store.calendars(for: .event)) { calendar in
+            calendar.source.sourceIdentifier
+        }
+
+        calendarSourceGroups = grouped.map { sourceID, calendars in
+            let sortedCalendars = calendars.sorted {
+                $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending
+            }
+            let sourceTitle = sortedCalendars.first?.source.title ?? "Calendars"
+            return CalendarSourceGroup(
+                id: sourceID,
+                title: sourceTitle,
+                calendars: sortedCalendars.map { calendar in
+                    CalendarDisplayOption(
+                        id: calendar.calendarIdentifier,
+                        title: calendar.title,
+                        sourceID: sourceID,
+                        sourceTitle: sourceTitle,
+                        color: calendar.cgColor,
+                        type: calendar.type
+                    )
+                }
+            )
+        }
+        .sorted { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }
+    }
+
+    private var allCalendarIDs: [String] {
+        calendarSourceGroups.flatMap { $0.calendars.map(\.id) }
     }
 
     // MARK: - Fetching
@@ -70,8 +217,9 @@ final class CalendarManager: ObservableObject {
             let events = storeRef.events(matching: predicate).sorted { $0.startDate < $1.startDate }
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
-                self.todayEvents = events
-                self.nextEvent = events.first { $0.startDate > Date() }
+                let visibleEvents = self.visibleEvents(from: events)
+                self.todayEvents = visibleEvents
+                self.nextEvent = visibleEvents.first { $0.startDate > Date() }
                 self.schedulePreEventNotification()
                 self.fetchEventsForSelectedDate()
                 self.fetchUpcomingWeekEvents()
@@ -107,6 +255,8 @@ final class CalendarManager: ObservableObject {
     // MARK: - Refresh
 
     private func startRefreshTimer() {
+        guard refreshTimer == nil else { return }
+
         // Refresh every 5 minutes
         refreshTimer = Timer.scheduledTimer(withTimeInterval: 300, repeats: true) { [weak self] _ in
             Task { @MainActor in
@@ -121,6 +271,12 @@ final class CalendarManager: ObservableObject {
             name: .NSCalendarDayChanged,
             object: nil
         )
+    }
+
+    private func stopRefreshTimer() {
+        refreshTimer?.invalidate()
+        refreshTimer = nil
+        NotificationCenter.default.removeObserver(self, name: .NSCalendarDayChanged, object: nil)
     }
 
     @objc private func dayChanged() {
@@ -161,7 +317,8 @@ final class CalendarManager: ObservableObject {
         let patterns = [
             "https://[\\w.-]+\\.zoom\\.us/[\\w/?=&-]+",
             "https://meet\\.google\\.com/[\\w-]+",
-            "https://teams\\.microsoft\\.com/[\\w/?=&-]+"
+            "https://teams\\.microsoft\\.com/[\\w/?=&-]+",
+            "https?://[^\\s<>]+"
         ]
 
         for text in searchTexts {
@@ -189,7 +346,9 @@ final class CalendarManager: ObservableObject {
 
         calendarQueue.async { [weak self] in
             let events = storeRef.events(matching: predicate).sorted { $0.startDate < $1.startDate }
-            DispatchQueue.main.async { self?.selectedDateEvents = events }
+            DispatchQueue.main.async { [weak self] in
+                self?.selectedDateEvents = self?.visibleEvents(from: events) ?? []
+            }
         }
     }
 
@@ -197,36 +356,38 @@ final class CalendarManager: ObservableObject {
         guard hasAccess else { return }
         let cal = Foundation.Calendar.current
         let tomorrow = cal.date(byAdding: .day, value: 1, to: cal.startOfDay(for: Date()))!
-        let weekEnd = cal.date(byAdding: .day, value: 7, to: tomorrow)!
+        let weekEnd = cal.date(byAdding: .day, value: lookaheadDays, to: tomorrow)!
         let predicate = store.predicateForEvents(withStart: tomorrow, end: weekEnd, calendars: nil)
         let storeRef = store
 
         calendarQueue.async { [weak self] in
             let allEvents = storeRef.events(matching: predicate).sorted { $0.startDate < $1.startDate }
 
-            var grouped: [(date: Date, events: [EKEvent])] = []
-            var currentDay: Date?
-            var currentEvents: [EKEvent] = []
-
-            for event in allEvents {
-                let day = cal.startOfDay(for: event.startDate)
-                if day != currentDay {
-                    if let prev = currentDay, !currentEvents.isEmpty {
-                        grouped.append((date: prev, events: currentEvents))
-                    }
-                    currentDay = day
-                    currentEvents = [event]
-                } else {
-                    currentEvents.append(event)
-                }
-            }
-            if let last = currentDay, !currentEvents.isEmpty {
-                grouped.append((date: last, events: currentEvents))
-            }
-
             DispatchQueue.main.async { [weak self] in
-                self?.upcomingWeekEvents = grouped
-                self?.prefetchDatesWithEventsIfNeeded()
+                guard let self else { return }
+                let visibleEvents = self.visibleEvents(from: allEvents)
+                var grouped: [(date: Date, events: [EKEvent])] = []
+                var currentDay: Date?
+                var currentEvents: [EKEvent] = []
+
+                for event in visibleEvents {
+                    let day = cal.startOfDay(for: event.startDate)
+                    if day != currentDay {
+                        if let prev = currentDay, !currentEvents.isEmpty {
+                            grouped.append((date: prev, events: currentEvents))
+                        }
+                        currentDay = day
+                        currentEvents = [event]
+                    } else {
+                        currentEvents.append(event)
+                    }
+                }
+                if let last = currentDay, !currentEvents.isEmpty {
+                    grouped.append((date: last, events: currentEvents))
+                }
+
+                self.upcomingWeekEvents = grouped
+                self.prefetchDatesWithEventsIfNeeded()
             }
         }
     }
@@ -247,12 +408,91 @@ final class CalendarManager: ObservableObject {
 
         calendarQueue.async { [weak self] in
             let events = storeRef.events(matching: predicate)
-            var dates = Set<Date>()
-            for event in events {
-                dates.insert(cal.startOfDay(for: event.startDate))
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                var dates = Set<Date>()
+                for event in self.visibleEvents(from: events) {
+                    dates.insert(cal.startOfDay(for: event.startDate))
+                }
+                self.datesWithEvents = dates
             }
-            DispatchQueue.main.async { self?.datesWithEvents = dates }
         }
+    }
+
+    private func refreshEventsAfterPreferenceChange() {
+        guard hasAccess else { return }
+        fetchTodayEvents()
+        fetchEventsForSelectedDate()
+        fetchUpcomingWeekEvents()
+        prefetchDatesWithEventsIfNeeded()
+    }
+
+    private func clearEvents() {
+        calendarSourceGroups = []
+        todayEvents = []
+        nextEvent = nil
+        selectedDateEvents = []
+        upcomingWeekEvents = []
+        datesWithEvents = []
+        preEventTimer?.invalidate()
+        preEventTimer = nil
+    }
+
+    private func visibleEvents(from events: [EKEvent]) -> [EKEvent] {
+        let filtered = events.filter { event in
+            guard let calendar = event.calendar else { return false }
+            guard isCalendarEnabled(calendar.calendarIdentifier) else { return false }
+            if hideBirthdays, isBirthdayCalendar(calendar) { return false }
+            if hideHolidays, isHolidayCalendar(calendar) { return false }
+            return true
+        }
+
+        let events = collapseDuplicates ? collapseDuplicateEvents(filtered) : filtered
+        return events.sorted { $0.startDate < $1.startDate }
+    }
+
+    private func isBirthdayCalendar(_ calendar: EKCalendar) -> Bool {
+        calendar.type == .birthday || calendar.title.localizedCaseInsensitiveContains("birthday")
+    }
+
+    private func isHolidayCalendar(_ calendar: EKCalendar) -> Bool {
+        let calendarTitle = calendar.title.lowercased()
+        let sourceTitle = calendar.source.title.lowercased()
+        return calendarTitle.contains("holiday") || sourceTitle.contains("holiday")
+    }
+
+    private func collapseDuplicateEvents(_ events: [EKEvent]) -> [EKEvent] {
+        var collapsed: [EKEvent] = []
+        for event in events {
+            guard !collapsed.contains(where: { isDuplicateEvent($0, event) }) else { continue }
+            collapsed.append(event)
+        }
+        return collapsed
+    }
+
+    private func isDuplicateEvent(_ lhs: EKEvent, _ rhs: EKEvent) -> Bool {
+        guard normalizedEventTitle(lhs) == normalizedEventTitle(rhs),
+              lhs.startDate == rhs.startDate,
+              lhs.endDate == rhs.endDate,
+              lhs.isAllDay == rhs.isAllDay else {
+            return false
+        }
+
+        let leftLocation = normalizedEventLocation(lhs)
+        let rightLocation = normalizedEventLocation(rhs)
+        return leftLocation == rightLocation || leftLocation.isEmpty || rightLocation.isEmpty
+    }
+
+    private func normalizedEventTitle(_ event: EKEvent) -> String {
+        (event.title ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+    }
+
+    private func normalizedEventLocation(_ event: EKEvent) -> String {
+        (event.location ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
     }
 
     private func changeDisplayedMonth(by offset: Int) {
@@ -270,6 +510,7 @@ final class CalendarManager: ObservableObject {
 
     deinit {
         refreshTimer?.invalidate()
+        NotificationCenter.default.removeObserver(self, name: .NSCalendarDayChanged, object: nil)
         preEventTimer?.invalidate()
     }
 }

--- a/SuperIsland/Settings/ModuleSettingsView.swift
+++ b/SuperIsland/Settings/ModuleSettingsView.swift
@@ -1,7 +1,10 @@
+import AppKit
+import EventKit
 import SwiftUI
 
 struct ModuleSettingsView: View {
     @EnvironmentObject var appState: AppState
+    @ObservedObject private var calendarManager = CalendarManager.shared
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -26,7 +29,32 @@ struct ModuleSettingsView: View {
 
             SettingSectionLabel(title: "Information")
             SettingGroup {
-                SettingToggleRow(title: "Calendar", isOn: $appState.calendarEnabled)
+                SettingToggleRow(title: "Calendar", isOn: calendarEnabledBinding)
+                if appState.calendarEnabled {
+                    SettingRowDivider()
+                    calendarPermissionRow
+                    if calendarManager.hasAccess {
+                        SettingRowDivider()
+                        SettingToggleRow(
+                            title: "Collapse duplicate events",
+                            description: "Hide repeated holidays or birthdays with the same title and time.",
+                            isOn: $calendarManager.collapseDuplicates
+                        )
+                        SettingRowDivider()
+                        SettingToggleRow(
+                            title: "Hide holidays",
+                            isOn: $calendarManager.hideHolidays
+                        )
+                        SettingRowDivider()
+                        SettingToggleRow(
+                            title: "Hide birthdays",
+                            isOn: $calendarManager.hideBirthdays
+                        )
+                        SettingRowDivider()
+                        calendarLookaheadRow
+                        calendarSourceRows
+                    }
+                }
                 SettingRowDivider()
                 SettingToggleRow(title: "Weather", isOn: $appState.weatherEnabled)
                 SettingRowDivider()
@@ -65,5 +93,182 @@ struct ModuleSettingsView: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .topLeading)
+        .onAppear { calendarManager.refreshAccessStatus() }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            calendarManager.refreshAccessStatus()
+        }
+    }
+
+    private var calendarPermissionRow: some View {
+        HStack(alignment: .top, spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Calendar access")
+                    .font(.system(size: 13))
+                Text(calendarPermissionDescription)
+                    .font(.system(size: 11))
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 12)
+            Button(calendarPermissionButtonTitle) {
+                handleCalendarPermissionAction()
+            }
+            .font(.system(size: 12))
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 11)
+    }
+
+    private var calendarLookaheadRow: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Upcoming range")
+                    .font(.system(size: 13))
+                Text("How many days appear in the Upcoming column.")
+                    .font(.system(size: 11))
+                    .foregroundColor(.secondary)
+            }
+            Spacer(minLength: 12)
+            StepperField(
+                value: calendarLookaheadBinding,
+                step: 1,
+                range: 1...30
+            ) { "\(Int($0))d" }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 11)
+    }
+
+    @ViewBuilder
+    private var calendarSourceRows: some View {
+        if calendarManager.calendarSourceGroups.isEmpty {
+            SettingRowDivider()
+            Text("No calendars available")
+                .font(.system(size: 12))
+                .foregroundColor(.secondary)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 11)
+        } else {
+            ForEach(calendarManager.calendarSourceGroups) { group in
+                SettingRowDivider()
+                Text(group.title)
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(.secondary)
+                    .padding(.horizontal, 16)
+                    .padding(.top, 12)
+                    .padding(.bottom, 4)
+
+                ForEach(group.calendars) { calendar in
+                    calendarSourceRow(calendar)
+                    if calendar.id != group.calendars.last?.id {
+                        SettingRowDivider()
+                    }
+                }
+            }
+        }
+    }
+
+    private func calendarSourceRow(_ calendar: CalendarDisplayOption) -> some View {
+        HStack(spacing: 12) {
+            Circle()
+                .fill(Color(cgColor: calendar.color))
+                .frame(width: 9, height: 9)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(calendar.title)
+                    .font(.system(size: 13))
+                Text(calendarTypeLabel(calendar.type))
+                    .font(.system(size: 11))
+                    .foregroundColor(.secondary)
+            }
+
+            Spacer(minLength: 8)
+
+            Toggle("", isOn: calendarEnabledBinding(for: calendar.id))
+                .labelsHidden()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+    }
+
+    private var calendarEnabledBinding: Binding<Bool> {
+        Binding(
+            get: { appState.calendarEnabled },
+            set: { newValue in
+                appState.calendarEnabled = newValue
+                if newValue {
+                    calendarManager.refreshAccessStatus()
+                    if calendarManager.authorizationStatus == .notDetermined {
+                        calendarManager.requestAccess()
+                    }
+                }
+            }
+        )
+    }
+
+    private var calendarLookaheadBinding: Binding<Double> {
+        Binding(
+            get: { Double(calendarManager.lookaheadDays) },
+            set: { calendarManager.lookaheadDays = Int($0) }
+        )
+    }
+
+    private func calendarEnabledBinding(for calendarID: String) -> Binding<Bool> {
+        Binding(
+            get: { calendarManager.isCalendarEnabled(calendarID) },
+            set: { calendarManager.setCalendar(calendarID, enabled: $0) }
+        )
+    }
+
+    private var calendarPermissionDescription: String {
+        switch calendarManager.authorizationStatus {
+        case .fullAccess, .authorized:
+            return "Allowed. Choose which calendars appear in SuperIsland."
+        case .notDetermined:
+            return "Not requested. Allow access to show upcoming events."
+        case .denied:
+            return "Denied. Open System Settings to allow Calendar access."
+        case .restricted:
+            return "Restricted by macOS settings."
+        case .writeOnly:
+            return "Write-only access is not enough to display events."
+        @unknown default:
+            return "Unknown. Check macOS Calendar privacy settings."
+        }
+    }
+
+    private var calendarPermissionButtonTitle: String {
+        switch calendarManager.authorizationStatus {
+        case .notDetermined:
+            return "Request"
+        default:
+            return "Open Settings"
+        }
+    }
+
+    private func handleCalendarPermissionAction() {
+        switch calendarManager.authorizationStatus {
+        case .notDetermined:
+            calendarManager.requestAccess()
+        default:
+            calendarManager.openCalendarSettings()
+        }
+    }
+
+    private func calendarTypeLabel(_ type: EKCalendarType) -> String {
+        switch type {
+        case .local:
+            return "Local"
+        case .calDAV:
+            return "CalDAV"
+        case .exchange:
+            return "Exchange"
+        case .subscription:
+            return "Subscription"
+        case .birthday:
+            return "Birthdays"
+        @unknown default:
+            return "Calendar"
+        }
     }
 }

--- a/docs/CALENDAR.md
+++ b/docs/CALENDAR.md
@@ -1,0 +1,21 @@
+# Calendar
+
+The Calendar module reads events through EventKit after the user grants Calendar access.
+
+## Source selection
+
+Settings -> Modules -> Calendar shows calendars grouped by account/source. The first launch keeps all calendars enabled. Once the user changes any calendar toggle, that explicit selection is used for:
+
+- Today's events
+- The selected day
+- Upcoming events
+- Calendar grid event indicators
+- Pre-event island reminders
+
+## Duplicate and clutter filters
+
+The module can hide birthday calendars, hide holiday calendars, and collapse duplicate events. Duplicate collapse compares title, start/end time, all-day state, and location when available.
+
+## Meeting links
+
+Meeting links are detected from event notes and location fields. Zoom, Google Meet, Microsoft Teams, and generic web links can be opened or copied from the expanded calendar view.


### PR DESCRIPTION
## Summary
- Adds a Calendar settings area for access status, source selection, upcoming range, holiday filtering, birthday filtering, and duplicate collapse.
- Applies the selected calendar sources and filters to today, selected day, upcoming events, grid indicators, and pre-event reminders.
- Adds expanded-view actions to open/copy detected meeting links and hide an event's calendar.
- Adds Calendar documentation and links it from the README.

## Issue Relevance Check
- Addresses #72.
- Verified the issue matches SuperIsland's current Calendar module and Settings module: it asks for choosing which calendars appear and reducing duplicate calendar clutter.
- Checked CalendarManager, CalendarExpandedView, and ModuleSettingsView before implementation.

## Validation
- `git diff --check` passed.
- Direct Swift typecheck passed with existing project warnings.
- Xcode version check passed: Xcode 26.5, build 17F42.
- Project generation check could not run because the generator command is not installed in this environment.

## Screenshots Needed
- Settings -> Modules -> Calendar with calendar source rows visible.
- Expanded Calendar view showing meeting-link actions and hide-calendar action.

## Risk Notes
- EventKit calendar identifiers can change after account re-syncs, so users may need to reselect sources after account changes.
- Holiday filtering is based on calendar/source titles because EventKit does not expose a universal holiday-calendar marker.
- Manual verification with multiple calendar accounts is recommended.