### PR TITLE
Add home layout customization and animation polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ scripts/            Build & release scripts
 
 Extensions are JavaScript packages that run inside a sandboxed JavaScriptCore context. Read the full guide at [dynamicisland.app/docs](https://dynamicisland.app/docs) or in [EXTENSIONS.md](EXTENSIONS.md).
 
+## Appearance
+
+Home slots, compact island size, animation intensity, and reduced motion can be configured in Settings. See [docs/APPEARANCE.md](docs/APPEARANCE.md).
+
 ---
 
 ## Contributing

--- a/SuperIsland/App/AppState.swift
+++ b/SuperIsland/App/AppState.swift
@@ -263,8 +263,14 @@ final class AppState: ObservableObject {
     // Appearance settings
     @AppStorage("appearance.animationSpeed") var animationSpeed: Double = 1.0
     @AppStorage("appearance.bounceAmount") var bounceAmount: Double = 0.25
+    @AppStorage("appearance.animationLevel") var animationLevelRaw = AnimationLevel.full.rawValue
+    @AppStorage("appearance.reduceMotion") var reduceMotion = false
     @AppStorage("appearance.compactIslandWidth") var compactIslandWidth: Double = 200
     @AppStorage("appearance.compactIslandHeight") var compactIslandHeight: Double = 36
+
+    @AppStorage("home.leadingPanel") var homeLeadingPanelRaw = HomePanel.nowPlaying.rawValue
+    @AppStorage("home.centerPanel") var homeCenterPanelRaw = HomePanel.calendar.rawValue
+    @AppStorage("home.trailingPanel") var homeTrailingPanelRaw = HomePanel.weather.rawValue
 
     // General settings
     @AppStorage("general.showMenuBarIcon") var showMenuBarIcon = true
@@ -300,11 +306,55 @@ final class AppState: ObservableObject {
     /// Recomputed per-call so the live bounce-amount setting takes effect
     /// without needing an app relaunch.
     var notchAnimation: Animation {
-        .interactiveSpring(
-            duration: 0.5,
-            extraBounce: bounceAmount,
+        if shouldReduceMotion {
+            return .easeOut(duration: 0.14)
+        }
+
+        let level = animationLevel
+        let duration = 0.5 / max(0.5, animationSpeed)
+        let bounce = min(bounceAmount, level.bounceLimit)
+        return .interactiveSpring(
+            duration: duration,
+            extraBounce: bounce,
             blendDuration: 0.125
         )
+    }
+
+    var contentSwapAnimation: Animation {
+        shouldReduceMotion
+            ? .easeOut(duration: 0.12)
+            : .smooth(duration: 0.22 / max(0.5, animationSpeed))
+    }
+
+    var hoverAnimation: Animation {
+        shouldReduceMotion
+            ? .easeOut(duration: 0.08)
+            : .easeOut(duration: 0.18 / max(0.5, animationSpeed))
+    }
+
+    var shouldReduceMotion: Bool {
+        reduceMotion || animationLevel == .reduced
+    }
+
+    var animationLevel: AnimationLevel {
+        get { AnimationLevel(rawValue: animationLevelRaw) ?? .full }
+        set { animationLevelRaw = newValue.rawValue }
+    }
+
+    var homePanels: [HomePanel] {
+        let configured = [
+            HomePanel(rawValue: homeLeadingPanelRaw) ?? .nowPlaying,
+            HomePanel(rawValue: homeCenterPanelRaw) ?? .calendar,
+            HomePanel(rawValue: homeTrailingPanelRaw) ?? .weather
+        ]
+
+        var seen = Set<HomePanel>()
+        return configured.filter { panel in
+            guard panel != .none else { return false }
+            guard seen.insert(panel).inserted else { return false }
+            guard let module = panel.module else { return false }
+            return isModuleEnabled(module)
+        }
     }
 
     // MARK: - State Transitions
@@ -675,7 +725,7 @@ final class AppState: ObservableObject {
             nextModule = modules[modules.count - 1]
         }
 
-        withAnimation(Constants.contentSwap) {
+        withAnimation(contentSwapAnimation) {
             previousModule = activeModule
             activeModule = nextModule
         }
@@ -689,14 +739,14 @@ final class AppState: ObservableObject {
         if case .builtIn(let builtIn) = module, !isModuleEnabled(builtIn) {
             return
         }
-        withAnimation(Constants.contentSwap) {
+        withAnimation(contentSwapAnimation) {
             previousModule = activeModule
             activeModule = module
         }
     }
 
     func selectFullExpandedTab(_ tab: FullExpandedTab) {
-        withAnimation(Constants.contentSwap) {
+        withAnimation(contentSwapAnimation) {
             fullExpandedSelectedTab = tab
         }
 
@@ -708,7 +758,7 @@ final class AppState: ObservableObject {
     }
 
     func showHomeTab() {
-        withAnimation(Constants.contentSwap) {
+        withAnimation(contentSwapAnimation) {
             fullExpandedSelectedTab = .home
         }
         shelfDefaultToShelf = false
@@ -1197,7 +1247,7 @@ final class AppState: ObservableObject {
             : (currentIndex - 1 + tabs.count) % tabs.count
         let nextTab = tabs[nextIndex]
 
-        withAnimation(Constants.contentSwap) {
+        withAnimation(contentSwapAnimation) {
             fullExpandedSelectedTab = nextTab
             if case .module(let module) = nextTab {
                 previousModule = activeModule
@@ -1252,7 +1302,7 @@ final class AppState: ObservableObject {
         activeModule = .builtIn(.shelf)
         fullExpandedSelectedTab = .module(.builtIn(.shelf))
 
-        withAnimation(currentState == .compact ? notchAnimation : Constants.contentSwap) {
+        withAnimation(currentState == .compact ? notchAnimation : contentSwapAnimation) {
             currentState = .fullExpanded
         }
     }
@@ -1269,7 +1319,7 @@ final class AppState: ObservableObject {
         activeModule = .builtIn(.shelf)
         fullExpandedSelectedTab = .module(.builtIn(.shelf))
 
-        withAnimation(currentState == .compact ? notchAnimation : Constants.contentSwap) {
+        withAnimation(currentState == .compact ? notchAnimation : contentSwapAnimation) {
             currentState = .fullExpanded
         }
     }

--- a/SuperIsland/Home/HomeLayoutPreferences.swift
+++ b/SuperIsland/Home/HomeLayoutPreferences.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+enum HomePanel: String, CaseIterable, Identifiable {
+    case none
+    case nowPlaying
+    case calendar
+    case weather
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .none: return "Empty"
+        case .nowPlaying: return "Now Playing"
+        case .calendar: return "Calendar"
+        case .weather: return "Weather"
+        }
+    }
+
+    var iconName: String {
+        switch self {
+        case .none: return "minus.circle"
+        case .nowPlaying: return "music.note"
+        case .calendar: return "calendar"
+        case .weather: return "cloud.sun.fill"
+        }
+    }
+
+    var module: ModuleType? {
+        switch self {
+        case .none: return nil
+        case .nowPlaying: return .nowPlaying
+        case .calendar: return .calendar
+        case .weather: return .weather
+        }
+    }
+}
+
+enum AnimationLevel: String, CaseIterable, Identifiable {
+    case full
+    case subtle
+    case reduced
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .full: return "Full"
+        case .subtle: return "Subtle"
+        case .reduced: return "Reduced"
+        }
+    }
+
+    var bounceLimit: Double {
+        switch self {
+        case .full: return 0.5
+        case .subtle: return 0.08
+        case .reduced: return 0
+        }
+    }
+}

--- a/SuperIsland/Settings/AppearanceSettingsView.swift
+++ b/SuperIsland/Settings/AppearanceSettingsView.swift
@@ -7,6 +7,8 @@ struct AppearanceSettingsView: View {
     // and for the @AppStorage initial values in AppState.
     private enum Defaults {
         static let bounceAmount: Double = 0.25
+        static let animationLevel = AnimationLevel.full
+        static let reduceMotion = false
         static let compactIslandWidth: Double = 200
         static let compactIslandHeight: Double = 36
     }
@@ -17,9 +19,37 @@ struct AppearanceSettingsView: View {
             section(
                 title: "Animation",
                 reset: {
+                    appState.animationLevel = Defaults.animationLevel
+                    appState.reduceMotion = Defaults.reduceMotion
                     appState.bounceAmount = Defaults.bounceAmount
                 }
             ) {
+                HStack {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Animation intensity").font(.system(size: 13))
+                        Text("Controls island motion and transition strength")
+                            .font(.system(size: 11)).foregroundColor(.secondary)
+                    }
+                    Spacer(minLength: 12)
+                    Picker("", selection: $appState.animationLevelRaw) {
+                        ForEach(AnimationLevel.allCases) { level in
+                            Text(level.title).tag(level.rawValue)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                    .labelsHidden()
+                    .frame(width: 120)
+                }
+                .padding(.horizontal, 16).padding(.vertical, 12)
+
+                SettingRowDivider()
+                SettingToggleRow(
+                    title: "Reduce motion",
+                    description: "Simplify island transitions and content swaps",
+                    isOn: $appState.reduceMotion
+                )
+
+                SettingRowDivider()
                 HStack {
                     VStack(alignment: .leading, spacing: 2) {
                         Text("Bounce").font(.system(size: 13))

--- a/SuperIsland/Settings/ModuleSettingsView.swift
+++ b/SuperIsland/Settings/ModuleSettingsView.swift
@@ -13,6 +13,15 @@ struct ModuleSettingsView: View {
                 SettingToggleRow(title: "Volume HUD", isOn: $appState.volumeHUDEnabled)
             }
 
+            SettingSectionLabel(title: "Home")
+            SettingGroup {
+                homeSlotRow(title: "Left slot", selection: $appState.homeLeadingPanelRaw)
+                SettingRowDivider()
+                homeSlotRow(title: "Center slot", selection: $appState.homeCenterPanelRaw)
+                SettingRowDivider()
+                homeSlotRow(title: "Right slot", selection: $appState.homeTrailingPanelRaw)
+            }
+
             SettingSectionLabel(title: "System")
             SettingGroup {
                 SettingToggleRow(title: "Battery", isOn: $appState.batteryEnabled)
@@ -65,5 +74,24 @@ struct ModuleSettingsView: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .topLeading)
+    }
+
+    private func homeSlotRow(title: String, selection: Binding<String>) -> some View {
+        HStack {
+            Text(title)
+                .font(.system(size: 13))
+            Spacer(minLength: 12)
+            Picker("", selection: selection) {
+                ForEach(HomePanel.allCases) { panel in
+                    Label(panel.title, systemImage: panel.iconName)
+                        .tag(panel.rawValue)
+                }
+            }
+            .pickerStyle(.menu)
+            .labelsHidden()
+            .frame(width: 150)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 11)
     }
 }

--- a/SuperIsland/Views/HomeScreenView.swift
+++ b/SuperIsland/Views/HomeScreenView.swift
@@ -26,27 +26,20 @@ struct HomeScreenView: View {
     }
 
     private var visiblePanels: [HomePanel] {
-        var result: [HomePanel] = []
-        if appState.nowPlayingEnabled { result.append(.nowPlaying) }
-        if appState.calendarEnabled { result.append(.calendar) }
-        if appState.weatherEnabled { result.append(.weather) }
-        return result
+        appState.homePanels
     }
 
     private var threePanelLayout: some View {
         HStack(alignment: .top, spacing: 14) {
-            HomeNowPlayingPanel()
-                .frame(width: 228, alignment: .topLeading)
+            ForEach(Array(visiblePanels.enumerated()), id: \.element.id) { index, panel in
+                panelView(for: panel)
+                    .frame(width: preferredWidth(for: panel), alignment: .topLeading)
+                    .frame(maxWidth: panel == .calendar ? .infinity : nil, alignment: .topLeading)
 
-            homeDivider
-
-            HomeCalendarPanel()
-                .frame(maxWidth: .infinity, alignment: .topLeading)
-
-            homeDivider
-
-            HomeWeatherPanel()
-                .frame(width: 150, alignment: .topLeading)
+                if index < visiblePanels.count - 1 {
+                    homeDivider
+                }
+            }
         }
     }
 
@@ -66,6 +59,8 @@ struct HomeScreenView: View {
     @ViewBuilder
     private func panelView(for panel: HomePanel) -> some View {
         switch panel {
+        case .none:
+            EmptyView()
         case .nowPlaying:
             HomeNowPlayingPanel()
         case .calendar:
@@ -81,14 +76,17 @@ struct HomeScreenView: View {
             .frame(width: 1)
             .padding(.vertical, 4)
     }
-}
 
-private enum HomePanel: String, Identifiable {
-    case nowPlaying
-    case calendar
-    case weather
-
-    var id: String { rawValue }
+    private func preferredWidth(for panel: HomePanel) -> CGFloat? {
+        switch panel {
+        case .nowPlaying:
+            return visiblePanels.count == 3 ? 228 : nil
+        case .weather:
+            return visiblePanels.count == 3 ? 150 : nil
+        case .calendar, .none:
+            return nil
+        }
+    }
 }
 
 private struct HomeNowPlayingPanel: View {

--- a/SuperIsland/Views/IslandContainerView.swift
+++ b/SuperIsland/Views/IslandContainerView.swift
@@ -82,7 +82,7 @@ struct IslandContainerView: View {
             onDragEnded: { handleSwipe(value: $0) }
         ))
         .onContinuousHover(coordinateSpace: .local) { phase in
-            handleSurfaceHover(phase: phase, surfaceSize: surfaceSize)
+            handleSurfaceHover(phase: phase)
         }
         .onTapGesture {
             handleSurfaceTap()
@@ -113,17 +113,11 @@ struct IslandContainerView: View {
             CompactView()
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
                 .opacity(compactContentOpacity)
-                .transition(
-                    .scale(scale: 0.85, anchor: .top)
-                    .combined(with: .opacity)
-                )
+                .transition(contentTransition(scale: 0.85))
         } else {
             expandedIslandLayout
                 .opacity(compactContentOpacity)
-                .transition(
-                    .scale(scale: 0.5, anchor: .top)
-                    .combined(with: .opacity)
-                )
+                .transition(contentTransition(scale: 0.5))
         }
     }
 
@@ -146,6 +140,12 @@ struct IslandContainerView: View {
 
     private var compactContentOpacity: Double {
         1.0
+    }
+
+    private func contentTransition(scale: CGFloat) -> AnyTransition {
+        appState.shouldReduceMotion
+            ? .opacity
+            : .scale(scale: scale, anchor: .top).combined(with: .opacity)
     }
 
     // Shadows are intentionally disabled in the compact state. The island
@@ -338,7 +338,7 @@ struct IslandContainerView: View {
         .frame(width: windowWidth, height: appState.currentContentFrameHeight, alignment: .center)
         .frame(maxHeight: .infinity, alignment: .top)
         .opacity(appState.isHovering ? 1 : 0.78)
-        .animation(.easeOut(duration: 0.18), value: appState.isHovering)
+        .animation(appState.hoverAnimation, value: appState.isHovering)
         .transition(.opacity)
         .allowsHitTesting(appState.currentState != .compact)
     }
@@ -378,20 +378,10 @@ struct IslandContainerView: View {
         syncHoverState()
     }
 
-    private func handleSurfaceHover(phase: HoverPhase, surfaceSize: CGSize) {
+    private func handleSurfaceHover(phase: HoverPhase) {
         switch phase {
-        case .active(let location):
-            guard appState.currentState == .compact,
-                  appState.shouldUseMinimalCompactLayout else {
-                setIslandSurfaceHover(true)
-                return
-            }
-
-            let centerGapWidth = appState.compactMinimalCenterGapWidth
-            let centerMinX = max(0, (surfaceSize.width - centerGapWidth) / 2)
-            let centerMaxX = min(surfaceSize.width, centerMinX + centerGapWidth)
-            let hoveringCenter = location.x >= centerMinX && location.x <= centerMaxX
-            setIslandSurfaceHover(hoveringCenter)
+        case .active:
+            setIslandSurfaceHover(true)
         case .ended:
             setIslandSurfaceHover(false)
         }

--- a/docs/APPEARANCE.md
+++ b/docs/APPEARANCE.md
@@ -1,0 +1,24 @@
+# Appearance and Home Layout
+
+SuperIsland lets users tune the compact island without changing module behavior.
+
+## Home slots
+
+Settings -> Modules -> Home contains three compact home slots:
+
+- Left slot
+- Center slot
+- Right slot
+
+Each slot can show Now Playing, Calendar, Weather, or Empty. Duplicate selections are ignored, and disabled modules stay hidden until the module is enabled again.
+
+## Motion
+
+Settings -> Appearance includes:
+
+- Animation intensity: Full, Subtle, or Reduced
+- Reduce motion: simplifies island transitions and content swaps
+- Bounce: fine-tunes spring bounce when motion is not reduced
+- Compact island width and height controls
+
+Reduced motion also removes scale-heavy content transitions in the island surface.


### PR DESCRIPTION
## Summary
- Adds configurable Home slots for Now Playing, Calendar, Weather, and Empty across the left, center, and right positions.
- Adds animation intensity and Reduce Motion settings so users can reduce bounce and simplify transitions.
- Makes the compact island hover surface respond across the full island, addressing the minimal-layout hover gap.
- Documents the new appearance and Home layout settings.

## Issue relevance
- Addresses #50.
- Verified the issue maps to SuperIsland's current Home layout, compact hover behavior, and animation settings.
- Checked AppState, IslandContainerView, HomeScreenView, AppearanceSettingsView, and ModuleSettingsView before implementation.

## Validation
- `git diff --check`
- Direct Swift typecheck passed with existing project warnings.
- `xcodebuild -version` passed with Xcode 26.5, build 17F42.
- `xcodegen generate` could not run because `xcodegen` is not installed in this environment.

## Screenshots needed
- Settings -> Modules -> Home slot pickers.
- Settings -> Appearance animation intensity and Reduce Motion controls.
- Compact island hover and Home layout behavior.

## Risk notes
- Reduced motion is an app setting in this PR; it does not automatically follow the system accessibility setting yet.
- Duplicate Home slot selections are ignored rather than shown twice.
- Manual hover testing on a notched Mac is recommended.