### PR TITLE
Add local File Shelf MVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ scripts/            Build & release scripts
 
 Extensions are JavaScript packages that run inside a sandboxed JavaScriptCore context. Read the full guide at [dynamicisland.app/docs](https://dynamicisland.app/docs) or in [EXTENSIONS.md](EXTENSIONS.md).
 
+## File Shelf
+
+The built-in Shelf module can stage local files, folders, URLs, text snippets, and images from the island. See [docs/SHELF.md](docs/SHELF.md).
+
 ---
 
 ## Contributing

--- a/SuperIsland/Modules/Shelf/ShelfStore.swift
+++ b/SuperIsland/Modules/Shelf/ShelfStore.swift
@@ -1,11 +1,34 @@
 import AppKit
 import Foundation
+import Quartz
 import UniformTypeIdentifiers
 
 enum ShelfItemKind: String, Codable, Hashable {
     case file
+    case folder
+    case image
     case link
     case text
+}
+
+enum ShelfRetentionOption: Int, CaseIterable, Identifiable {
+    case never = 0
+    case oneDay = 1
+    case oneWeek = 7
+    case oneMonth = 30
+    case threeMonths = 90
+
+    var id: Int { rawValue }
+
+    var title: String {
+        switch self {
+        case .never: return "Never"
+        case .oneDay: return "1 day"
+        case .oneWeek: return "7 days"
+        case .oneMonth: return "30 days"
+        case .threeMonths: return "90 days"
+        }
+    }
 }
 
 struct ShelfItem: Identifiable, Codable, Hashable {
@@ -17,6 +40,8 @@ struct ShelfItem: Identifiable, Codable, Hashable {
     let urlString: String?
     let textValue: String?
     let addedAt: Date
+    var lastAccessedAt: Date?
+    var isPinned: Bool
 
     init(
         id: UUID = UUID(),
@@ -26,7 +51,9 @@ struct ShelfItem: Identifiable, Codable, Hashable {
         bookmarkData: Data? = nil,
         urlString: String? = nil,
         textValue: String? = nil,
-        addedAt: Date = Date()
+        addedAt: Date = Date(),
+        lastAccessedAt: Date? = nil,
+        isPinned: Bool = false
     ) {
         self.id = id
         self.kind = kind
@@ -36,6 +63,35 @@ struct ShelfItem: Identifiable, Codable, Hashable {
         self.urlString = urlString
         self.textValue = textValue
         self.addedAt = addedAt
+        self.lastAccessedAt = lastAccessedAt
+        self.isPinned = isPinned
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case kind
+        case displayName
+        case path
+        case bookmarkData
+        case urlString
+        case textValue
+        case addedAt
+        case lastAccessedAt
+        case isPinned
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decodeIfPresent(UUID.self, forKey: .id) ?? UUID()
+        kind = try container.decode(ShelfItemKind.self, forKey: .kind)
+        displayName = try container.decode(String.self, forKey: .displayName)
+        path = try container.decodeIfPresent(String.self, forKey: .path)
+        bookmarkData = try container.decodeIfPresent(Data.self, forKey: .bookmarkData)
+        urlString = try container.decodeIfPresent(String.self, forKey: .urlString)
+        textValue = try container.decodeIfPresent(String.self, forKey: .textValue)
+        addedAt = try container.decodeIfPresent(Date.self, forKey: .addedAt) ?? Date()
+        lastAccessedAt = try container.decodeIfPresent(Date.self, forKey: .lastAccessedAt)
+        isPinned = try container.decodeIfPresent(Bool.self, forKey: .isPinned) ?? false
     }
 
     static func file(from url: URL) -> ShelfItem {
@@ -44,8 +100,9 @@ struct ShelfItem: Identifiable, Codable, Hashable {
             includingResourceValuesForKeys: nil,
             relativeTo: nil
         )
+        let kind = fileKind(for: url)
         return ShelfItem(
-            kind: .file,
+            kind: kind,
             displayName: displayName(for: url),
             path: url.path,
             bookmarkData: bookmarkData
@@ -69,8 +126,8 @@ struct ShelfItem: Identifiable, Codable, Hashable {
 
     var dedupeKey: String {
         switch kind {
-        case .file:
-            return "file:\(resolvedFileURL?.standardizedFileURL.path ?? path ?? displayName)"
+        case .file, .folder, .image:
+            return "\(kind.rawValue):\(resolvedFileURL?.standardizedFileURL.path ?? path ?? displayName)"
         case .link:
             return "link:\(urlString ?? displayName)"
         case .text:
@@ -80,12 +137,18 @@ struct ShelfItem: Identifiable, Codable, Hashable {
 
     var subtitle: String {
         switch kind {
-        case .file:
+        case .file, .folder, .image:
+            if isMissing {
+                return "Missing"
+            }
             guard let url = resolvedFileURL ?? path.map({ URL(fileURLWithPath: $0) }) else {
                 return "File"
             }
-            if url.hasDirectoryPath {
+            if kind == .folder || url.hasDirectoryPath {
                 return "Folder"
+            }
+            if kind == .image {
+                return "Image"
             }
             let ext = url.pathExtension.trimmingCharacters(in: .whitespacesAndNewlines)
             return ext.isEmpty ? "File" : ext.uppercased()
@@ -100,7 +163,7 @@ struct ShelfItem: Identifiable, Codable, Hashable {
 
     var previewText: String? {
         switch kind {
-        case .file:
+        case .file, .folder, .image:
             guard let url = resolvedFileURL ?? path.map({ URL(fileURLWithPath: $0) }) else {
                 return nil
             }
@@ -117,7 +180,7 @@ struct ShelfItem: Identifiable, Codable, Hashable {
 
     var resolvedURL: URL? {
         switch kind {
-        case .file:
+        case .file, .folder, .image:
             return resolvedFileURL
         case .link:
             guard let urlString else { return nil }
@@ -149,9 +212,12 @@ struct ShelfItem: Identifiable, Codable, Hashable {
 
     var icon: NSImage {
         switch kind {
-        case .file:
+        case .file, .folder, .image:
             if let url = resolvedFileURL ?? path.map({ URL(fileURLWithPath: $0) }) {
                 return NSWorkspace.shared.icon(forFile: url.path)
+            }
+            if kind == .image {
+                return Self.symbolImage(systemName: "photo.fill")
             }
             return Self.symbolImage(systemName: "doc.fill")
         case .link:
@@ -159,6 +225,49 @@ struct ShelfItem: Identifiable, Codable, Hashable {
         case .text:
             return Self.symbolImage(systemName: "text.alignleft")
         }
+    }
+
+    var isFileBacked: Bool {
+        switch kind {
+        case .file, .folder, .image:
+            return true
+        case .link, .text:
+            return false
+        }
+    }
+
+    var canQuickLook: Bool {
+        isFileBacked && !isMissing
+    }
+
+    var isMissing: Bool {
+        guard isFileBacked else { return false }
+        guard let url = resolvedFileURL ?? path.map({ URL(fileURLWithPath: $0) }) else {
+            return true
+        }
+        return !FileManager.default.fileExists(atPath: url.path)
+    }
+
+    private static func fileKind(for url: URL) -> ShelfItemKind {
+        if url.hasDirectoryPath {
+            return .folder
+        }
+
+        if let values = try? url.resourceValues(forKeys: [.isDirectoryKey, .contentTypeKey]) {
+            if values.isDirectory == true {
+                return .folder
+            }
+            if values.contentType?.conforms(to: .image) == true {
+                return .image
+            }
+        }
+
+        if let type = UTType(filenameExtension: url.pathExtension),
+           type.conforms(to: .image) {
+            return .image
+        }
+
+        return .file
     }
 
     private static func displayName(for url: URL) -> String {
@@ -189,23 +298,34 @@ final class ShelfStore: ObservableObject {
     static let acceptedDropTypes: [UTType] = [
         .fileURL,
         .url,
+        .image,
         .utf8PlainText,
         .plainText,
         .text
     ]
 
     @Published private(set) var items: [ShelfItem]
+    @Published var retentionDays: Int {
+        didSet {
+            UserDefaults.standard.set(retentionDays, forKey: retentionKey)
+            pruneExpiredItems()
+        }
+    }
 
     private let storageKey = "module.shelf.items"
+    private let retentionKey = "module.shelf.retentionDays"
     private var activeAirDropService: NSSharingService?
+    private var activeSharingPicker: NSSharingServicePicker?
 
     private init() {
+        self.retentionDays = UserDefaults.standard.object(forKey: retentionKey) as? Int ?? ShelfRetentionOption.never.rawValue
         if let data = UserDefaults.standard.data(forKey: storageKey),
            let decoded = try? JSONDecoder().decode([ShelfItem].self, from: data) {
             self.items = decoded
         } else {
             self.items = []
         }
+        pruneExpiredItems()
     }
 
     var isEmpty: Bool {
@@ -249,30 +369,49 @@ final class ShelfStore: ObservableObject {
 
         guard addedCount > 0 else { return 0 }
         items = merged
+        pruneExpiredItems()
         persist()
         return addedCount
     }
 
     func remove(_ item: ShelfItem) {
+        removeManagedImages(for: [item])
         items.removeAll { $0.id == item.id }
         persist()
     }
 
     func clear() {
         guard !items.isEmpty else { return }
+        removeManagedImages(for: items)
         items.removeAll()
+        persist()
+    }
+
+    func clearUnpinned() {
+        let removedItems = items.filter { !$0.isPinned }
+        guard !removedItems.isEmpty else { return }
+        removeManagedImages(for: removedItems)
+        items.removeAll { !$0.isPinned }
+        persist()
+    }
+
+    func togglePinned(_ item: ShelfItem) {
+        guard let index = items.firstIndex(where: { $0.id == item.id }) else { return }
+        items[index].isPinned.toggle()
+        items[index].lastAccessedAt = Date()
         persist()
     }
 
     func open(_ item: ShelfItem) {
         switch item.kind {
-        case .file:
+        case .file, .folder, .image:
             withResolvedFileURL(for: item) { url in
                 NSWorkspace.shared.open(url)
             }
         case .link:
             if let url = item.resolvedURL {
                 NSWorkspace.shared.open(url)
+                touch(item)
             }
         case .text:
             copy(item)
@@ -280,9 +419,19 @@ final class ShelfStore: ObservableObject {
     }
 
     func reveal(_ item: ShelfItem) {
-        guard item.kind == .file else { return }
+        guard item.isFileBacked else { return }
         withResolvedFileURL(for: item) { url in
             NSWorkspace.shared.activateFileViewerSelecting([url])
+        }
+    }
+
+    func quickLook(_ item: ShelfItem) {
+        guard item.canQuickLook else {
+            NSSound.beep()
+            return
+        }
+        withResolvedFileURL(for: item) { url in
+            ShelfQuickLookController.shared.preview(url)
         }
     }
 
@@ -291,25 +440,37 @@ final class ShelfStore: ObservableObject {
         pasteboard.clearContents()
 
         switch item.kind {
-        case .file:
+        case .file, .folder, .image:
             if let url = item.resolvedFileURL {
                 pasteboard.writeObjects([url as NSURL])
+                touch(item)
             }
         case .link:
             if let urlString = item.urlString {
                 pasteboard.setString(urlString, forType: .string)
+                touch(item)
             }
         case .text:
             if let text = item.textValue {
                 pasteboard.setString(text, forType: .string)
+                touch(item)
             }
         }
     }
 
+    func copyPath(_ item: ShelfItem) {
+        guard item.isFileBacked,
+              let path = item.resolvedFileURL?.path ?? item.path else { return }
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(path, forType: .string)
+        touch(item)
+    }
+
     func dragProvider(for item: ShelfItem) -> NSItemProvider {
         switch item.kind {
-        case .file:
-            if let url = item.resolvedFileURL {
+        case .file, .folder, .image:
+            if let url = item.resolvedFileURL, !item.isMissing {
                 if let provider = NSItemProvider(contentsOf: url) {
                     return provider
                 }
@@ -355,6 +516,27 @@ final class ShelfStore: ObservableObject {
     func shareViaAirDrop(items: [ShelfItem]) {
         let rawItems = items.compactMap(airDropPayload(for:))
         shareViaAirDrop(rawItems: rawItems)
+        items.forEach(touch)
+    }
+
+    func share(items: [ShelfItem]) {
+        let rawItems = items.compactMap(sharingPayload(for:))
+        guard !rawItems.isEmpty else {
+            NSSound.beep()
+            return
+        }
+
+        guard let view = NSApp.keyWindow?.contentView
+                ?? NSApp.mainWindow?.contentView
+                ?? NSApp.windows.first(where: { $0.isVisible })?.contentView else {
+            NSSound.beep()
+            return
+        }
+
+        let picker = NSSharingServicePicker(items: rawItems)
+        activeSharingPicker = picker
+        picker.show(relativeTo: view.bounds, of: view, preferredEdge: .minY)
+        items.forEach(touch)
     }
 
     private func persist() {
@@ -365,22 +547,64 @@ final class ShelfStore: ObservableObject {
 
     private func withResolvedFileURL(for item: ShelfItem, _ action: (URL) -> Void) {
         guard let url = item.resolvedFileURL else { return }
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            NSSound.beep()
+            return
+        }
         let didAccess = url.startAccessingSecurityScopedResource()
         action(url)
         if didAccess {
             url.stopAccessingSecurityScopedResource()
         }
+        touch(item)
     }
 
     private func airDropPayload(for item: ShelfItem) -> Any? {
+        sharingPayload(for: item)
+    }
+
+    private func sharingPayload(for item: ShelfItem) -> Any? {
         switch item.kind {
-        case .file:
+        case .file, .folder, .image:
+            guard !item.isMissing else { return nil }
             return item.resolvedFileURL
         case .link:
             return item.resolvedURL
         case .text:
             return item.textValue
         }
+    }
+
+    private func touch(_ item: ShelfItem) {
+        guard let index = items.firstIndex(where: { $0.id == item.id }) else { return }
+        items[index].lastAccessedAt = Date()
+        persist()
+    }
+
+    private func pruneExpiredItems() {
+        guard retentionDays > 0 else { return }
+        let cutoff = Date().addingTimeInterval(TimeInterval(-retentionDays * 24 * 60 * 60))
+        let removedItems = items.filter { !$0.isPinned && $0.addedAt < cutoff }
+        guard !removedItems.isEmpty else { return }
+        removeManagedImages(for: removedItems)
+        items.removeAll { !$0.isPinned && $0.addedAt < cutoff }
+        persist()
+    }
+
+    private func removeManagedImages(for items: [ShelfItem]) {
+        for item in items {
+            guard item.kind == .image,
+                  let url = item.resolvedFileURL,
+                  isManagedImageURL(url) else { continue }
+            try? FileManager.default.removeItem(at: url)
+        }
+    }
+
+    private func isManagedImageURL(_ url: URL) -> Bool {
+        guard let storageURL = Self.imageStorageURL else { return false }
+        let storagePath = storageURL.standardizedFileURL.path
+        let itemPath = url.standardizedFileURL.path
+        return itemPath == storagePath || itemPath.hasPrefix(storagePath + "/")
     }
 
     private func shareViaAirDrop(rawItems: [Any]) {
@@ -419,6 +643,12 @@ final class ShelfStore: ObservableObject {
             return url.isFileURL ? .file(from: url) : .link(url)
         }
 
+        if provider.hasItemConformingToTypeIdentifier(UTType.image.identifier),
+           let data = await loadData(from: provider, type: .image),
+           let item = imageItem(from: data, type: .image) {
+            return item
+        }
+
         for type in [UTType.utf8PlainText, .plainText, .text] {
             guard provider.hasItemConformingToTypeIdentifier(type.identifier),
                   let string = await loadString(from: provider, type: type) else {
@@ -436,6 +666,35 @@ final class ShelfStore: ObservableObject {
         }
 
         return nil
+    }
+
+    private static func imageItem(from data: Data, type: UTType) -> ShelfItem? {
+        guard data.count <= 20 * 1024 * 1024,
+              let storageURL = imageStorageURL else {
+            return nil
+        }
+
+        let fileManager = FileManager.default
+        do {
+            try fileManager.createDirectory(at: storageURL, withIntermediateDirectories: true)
+            let fileExtension = type.preferredFilenameExtension ?? "png"
+            let fileURL = storageURL.appendingPathComponent("\(UUID().uuidString).\(fileExtension)")
+            try data.write(to: fileURL, options: [.atomic])
+            return ShelfItem(
+                kind: .image,
+                displayName: "Image",
+                path: fileURL.path
+            )
+        } catch {
+            return nil
+        }
+    }
+
+    private static var imageStorageURL: URL? {
+        FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)
+            .first?
+            .appendingPathComponent("SuperIsland", isDirectory: true)
+            .appendingPathComponent("ShelfImages", isDirectory: true)
     }
 
     private static func recognizedURL(from string: String) -> URL? {
@@ -494,6 +753,19 @@ final class ShelfStore: ObservableObject {
         return nil
     }
 
+    private static func loadData(from provider: NSItemProvider, type: UTType) async -> Data? {
+        await withCheckedContinuation { continuation in
+            provider.loadDataRepresentation(forTypeIdentifier: type.identifier) { data, error in
+                guard error == nil else {
+                    continuation.resume(returning: nil)
+                    return
+                }
+
+                continuation.resume(returning: data)
+            }
+        }
+    }
+
     private static func loadItem(from provider: NSItemProvider, typeIdentifier: String) async -> NSSecureCoding? {
         await withCheckedContinuation { continuation in
             provider.loadItem(forTypeIdentifier: typeIdentifier, options: nil) { item, error in
@@ -505,5 +777,57 @@ final class ShelfStore: ObservableObject {
                 continuation.resume(returning: item)
             }
         }
+    }
+}
+
+@MainActor
+private final class ShelfQuickLookController: NSObject, QLPreviewPanelDataSource, QLPreviewPanelDelegate {
+    static let shared = ShelfQuickLookController()
+
+    private var previewURLs: [URL] = []
+    private var scopedURLs: [URL] = []
+
+    func preview(_ url: URL) {
+        closeScopedURLs()
+
+        let didAccess = url.startAccessingSecurityScopedResource()
+        if didAccess {
+            scopedURLs = [url]
+        }
+
+        previewURLs = [url]
+        guard let panel = QLPreviewPanel.shared() else {
+            closeScopedURLs()
+            NSSound.beep()
+            return
+        }
+
+        panel.dataSource = self
+        panel.delegate = self
+        panel.reloadData()
+        panel.makeKeyAndOrderFront(nil)
+    }
+
+    nonisolated func numberOfPreviewItems(in panel: QLPreviewPanel!) -> Int {
+        MainActor.assumeIsolated {
+            previewURLs.count
+        }
+    }
+
+    nonisolated func previewPanel(_ panel: QLPreviewPanel!, previewItemAt index: Int) -> QLPreviewItem! {
+        MainActor.assumeIsolated {
+            previewURLs[index] as NSURL
+        }
+    }
+
+    nonisolated func previewPanelDidClose(_ panel: QLPreviewPanel!) {
+        Task { @MainActor in
+            closeScopedURLs()
+        }
+    }
+
+    private func closeScopedURLs() {
+        scopedURLs.forEach { $0.stopAccessingSecurityScopedResource() }
+        scopedURLs.removeAll()
     }
 }

--- a/SuperIsland/Modules/Shelf/ShelfViews.swift
+++ b/SuperIsland/Modules/Shelf/ShelfViews.swift
@@ -51,7 +51,7 @@ struct ShelfExpandedView: View {
                     .font(.system(size: 13, weight: .semibold))
                     .foregroundStyle(.white)
 
-                Text(shelf.items.isEmpty ? "Drop files, links, or text" : "\(shelf.items.count) saved")
+                Text(shelf.items.isEmpty ? "Drop files, links, images, or text" : "\(shelf.items.count) saved")
                     .font(.system(size: 11, weight: .medium))
                     .foregroundStyle(.white.opacity(0.58))
             }
@@ -66,7 +66,7 @@ struct ShelfExpandedView: View {
                         Text("Drop onto the island")
                             .font(.system(size: 14, weight: .semibold))
                             .foregroundStyle(.white)
-                        Text("Items stay pinned here until you remove them.")
+                        Text("Items stay here until you remove them.")
                             .font(.system(size: 11))
                             .foregroundStyle(.white.opacity(0.56))
                     }
@@ -93,20 +93,45 @@ struct ShelfExpandedView: View {
 struct ShelfFullExpandedView: View {
     @ObservedObject private var shelf = ShelfStore.shared
     @EnvironmentObject private var appState: AppState
+    @State private var searchText = ""
 
     var body: some View {
         HStack(spacing: 12) {
             AirDropDropPane()
                 .frame(width: 142)
 
-            TrayDropPane(items: orderedItems)
+            TrayDropPane(
+                items: filteredItems,
+                totalCount: orderedItems.count,
+                isFiltering: !trimmedSearchText.isEmpty,
+                searchText: $searchText
+            )
                 .environmentObject(appState)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 
     private var orderedItems: [ShelfItem] {
-        shelf.items
+        shelf.items.sorted { lhs, rhs in
+            if lhs.isPinned != rhs.isPinned {
+                return lhs.isPinned
+            }
+            return lhs.addedAt > rhs.addedAt
+        }
+    }
+
+    private var filteredItems: [ShelfItem] {
+        let query = trimmedSearchText.lowercased()
+        guard !query.isEmpty else { return orderedItems }
+        return orderedItems.filter { item in
+            item.displayName.localizedCaseInsensitiveContains(query)
+                || item.subtitle.localizedCaseInsensitiveContains(query)
+                || (item.previewText?.localizedCaseInsensitiveContains(query) ?? false)
+        }
+    }
+
+    private var trimmedSearchText: String {
+        searchText.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }
 
@@ -163,6 +188,9 @@ private struct AirDropDropPane: View {
 
 private struct TrayDropPane: View {
     let items: [ShelfItem]
+    let totalCount: Int
+    let isFiltering: Bool
+    @Binding var searchText: String
 
     @ObservedObject private var shelf = ShelfStore.shared
     @EnvironmentObject private var appState: AppState
@@ -180,7 +208,7 @@ private struct TrayDropPane: View {
                         )
                 )
 
-            if items.isEmpty {
+            if totalCount == 0 {
                 VStack(spacing: 12) {
                     Image(systemName: "tray.and.arrow.down")
                         .font(.system(size: 20, weight: .semibold))
@@ -194,44 +222,84 @@ private struct TrayDropPane: View {
             } else {
                 VStack(alignment: .leading, spacing: 10) {
                     HStack {
-                        Text("Tray")
+                        Text("Shelf")
                             .font(.system(size: 12, weight: .semibold))
                             .foregroundStyle(.white.opacity(0.72))
 
+                        Text(totalCount == 1 ? "1 item" : "\(totalCount) items")
+                            .font(.system(size: 10, weight: .medium))
+                            .foregroundStyle(.white.opacity(0.42))
+
                         Spacer(minLength: 8)
 
-                        Button("Clear") {
-                            shelf.clear()
+                        TextField("Search", text: $searchText)
+                            .textFieldStyle(.plain)
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundStyle(.white.opacity(0.86))
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 5)
+                            .frame(width: 150)
+                            .background(
+                                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                                    .fill(Color.white.opacity(0.06))
+                            )
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                                    .stroke(Color.white.opacity(0.08), lineWidth: 1)
+                            )
+
+                        Menu("Clear") {
+                            Button("Clear Unpinned") {
+                                shelf.clearUnpinned()
+                            }
+                            .disabled(!shelf.items.contains { !$0.isPinned })
+
+                            Button("Clear All") {
+                                shelf.clear()
+                            }
                         }
-                        .buttonStyle(.plain)
+                        .menuStyle(.borderlessButton)
+                        .fixedSize()
                         .font(.system(size: 11, weight: .semibold))
                         .foregroundStyle(.white.opacity(0.78))
                         .hoverPointer()
                     }
 
-                    Spacer(minLength: 0)
+                    if items.isEmpty && isFiltering {
+                        VStack(spacing: 8) {
+                            Image(systemName: "magnifyingglass")
+                                .font(.system(size: 17, weight: .semibold))
+                                .foregroundStyle(.white.opacity(0.64))
+                            Text("No matches")
+                                .font(.system(size: 12, weight: .semibold))
+                                .foregroundStyle(.white.opacity(0.68))
+                        }
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    } else {
+                        Spacer(minLength: 0)
 
-                    ScrollViewReader { proxy in
-                        ScrollView(.horizontal, showsIndicators: false) {
-                            HStack(spacing: 18) {
-                                ForEach(items) { item in
-                                    TrayItemTile(item: item)
-                                        .id(item.id)
+                        ScrollViewReader { proxy in
+                            ScrollView(.horizontal, showsIndicators: false) {
+                                HStack(spacing: 18) {
+                                    ForEach(items) { item in
+                                        TrayItemTile(item: item)
+                                            .id(item.id)
+                                    }
                                 }
+                                .padding(.horizontal, 4)
+                                .frame(maxHeight: .infinity, alignment: .center)
                             }
-                            .padding(.horizontal, 4)
-                            .frame(maxHeight: .infinity, alignment: .center)
+                            .frame(height: 88)
+                            .onAppear {
+                                scrollToLatest(using: proxy, animated: false)
+                            }
+                            .onChange(of: items.count) { _, _ in
+                                scrollToLatest(using: proxy, animated: true)
+                            }
                         }
-                        .frame(height: 88)
-                        .onAppear {
-                            scrollToLatest(using: proxy, animated: false)
-                        }
-                        .onChange(of: items.count) { _, _ in
-                            scrollToLatest(using: proxy, animated: true)
-                        }
-                    }
 
-                    Spacer(minLength: 0)
+                        Spacer(minLength: 0)
+                    }
                 }
                 .padding(14)
             }
@@ -246,13 +314,13 @@ private struct TrayDropPane: View {
     }
 
     private func scrollToLatest(using proxy: ScrollViewProxy, animated: Bool) {
-        guard let lastID = items.last?.id else { return }
+        guard let lastID = items.first?.id else { return }
         if animated {
             withAnimation(.smooth(duration: 0.22)) {
-                proxy.scrollTo(lastID, anchor: .trailing)
+                proxy.scrollTo(lastID, anchor: .leading)
             }
         } else {
-            proxy.scrollTo(lastID, anchor: .trailing)
+            proxy.scrollTo(lastID, anchor: .leading)
         }
     }
 }
@@ -297,6 +365,9 @@ private struct ExpandedShelfChip: View {
         .onDrag {
             shelf.dragProvider(for: item)
         }
+        .contextMenu {
+            ShelfItemActionsMenu(item: item)
+        }
     }
 }
 
@@ -309,6 +380,40 @@ private struct TrayItemTile: View {
         VStack(spacing: 6) {
             ZStack(alignment: .topTrailing) {
                 ShelfItemArtworkView(item: item, size: 42, cornerRadius: 9)
+
+                if item.isPinned {
+                    Image(systemName: "pin.fill")
+                        .font(.system(size: 8, weight: .bold))
+                        .foregroundStyle(.white.opacity(0.92))
+                        .frame(width: 15, height: 15)
+                        .background(.ultraThinMaterial, in: Circle())
+                        .background(
+                            Circle()
+                                .fill(Color.black.opacity(0.28))
+                        )
+                        .overlay(
+                            Circle()
+                                .stroke(Color.white.opacity(0.24), lineWidth: 1)
+                        )
+                        .offset(x: -34, y: -4)
+                }
+
+                if item.isMissing {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.system(size: 8, weight: .bold))
+                        .foregroundStyle(.yellow.opacity(0.95))
+                        .frame(width: 15, height: 15)
+                        .background(.ultraThinMaterial, in: Circle())
+                        .background(
+                            Circle()
+                                .fill(Color.black.opacity(0.28))
+                        )
+                        .overlay(
+                            Circle()
+                                .stroke(Color.white.opacity(0.24), lineWidth: 1)
+                        )
+                        .offset(x: -17, y: -4)
+                }
 
                 Button {
                     shelf.remove(item)
@@ -361,29 +466,76 @@ private struct TrayItemTile: View {
             shelf.dragProvider(for: item)
         }
         .contextMenu {
+            ShelfItemActionsMenu(item: item)
+        }
+    }
+}
+
+private struct ShelfItemActionsMenu: View {
+    let item: ShelfItem
+    @ObservedObject private var shelf = ShelfStore.shared
+
+    var body: some View {
+        Button(item.isPinned ? "Unpin" : "Pin") {
+            shelf.togglePinned(item)
+        }
+
+        if !item.isMissing {
             Button("Open") {
                 shelf.open(item)
             }
+        }
 
-            if item.kind == .file {
-                Button("Show in Finder") {
-                    shelf.reveal(item)
-                }
+        if item.canQuickLook {
+            Button("Quick Look") {
+                shelf.quickLook(item)
             }
+        }
 
-            Button(item.kind == .text ? "Copy Text" : "Copy") {
+        if item.isFileBacked && !item.isMissing {
+            Button("Show in Finder") {
+                shelf.reveal(item)
+            }
+        }
+
+        Divider()
+
+        if !item.isMissing || !item.isFileBacked {
+            Button(copyTitle) {
                 shelf.copy(item)
+            }
+        }
+
+        if item.isFileBacked {
+            Button("Copy Path") {
+                shelf.copyPath(item)
+            }
+        }
+
+        if !item.isMissing || !item.isFileBacked {
+            Divider()
+
+            Button("Share...") {
+                shelf.share(items: [item])
             }
 
             Button("Share via AirDrop") {
                 shelf.shareViaAirDrop(items: [item])
             }
+        }
 
-            Divider()
+        Divider()
 
-            Button("Remove") {
-                shelf.remove(item)
-            }
+        Button("Remove") {
+            shelf.remove(item)
+        }
+    }
+
+    private var copyTitle: String {
+        switch item.kind {
+        case .link: return "Copy Link"
+        case .text: return "Copy Text"
+        default: return "Copy Item"
         }
     }
 }
@@ -405,7 +557,7 @@ private struct ShelfItemArtworkView: View {
                 Image(nsImage: item.icon)
                     .resizable()
                     .aspectRatio(contentMode: .fit)
-                    .padding(item.kind == .file ? 0 : 2)
+                    .padding(item.isFileBacked ? 0 : 2)
             }
         }
         .frame(width: size, height: size)
@@ -419,7 +571,7 @@ private struct ShelfItemArtworkView: View {
 @MainActor
 private enum ShelfThumbnailLoader {
     static func thumbnail(for item: ShelfItem, size: CGFloat) async -> NSImage? {
-        guard item.kind == .file, let url = item.resolvedFileURL else {
+        guard item.isFileBacked, !item.isMissing, let url = item.resolvedFileURL else {
             return nil
         }
 

--- a/SuperIsland/Settings/ModuleSettingsView.swift
+++ b/SuperIsland/Settings/ModuleSettingsView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct ModuleSettingsView: View {
     @EnvironmentObject var appState: AppState
+    @ObservedObject private var shelf = ShelfStore.shared
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -20,6 +21,8 @@ struct ModuleSettingsView: View {
                 SettingToggleRow(title: "Shelf", isOn: $appState.shelfEnabled)
                 SettingRowDivider()
                 SettingToggleRow(title: "Auto-open Shelf on Drop", isOn: $appState.shelfAutoOpenOnDrop)
+                SettingRowDivider()
+                shelfRetentionRow
                 SettingRowDivider()
                 SettingToggleRow(title: "Connectivity", isOn: $appState.connectivityEnabled)
             }
@@ -65,5 +68,28 @@ struct ModuleSettingsView: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .topLeading)
+    }
+
+    private var shelfRetentionRow: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Shelf retention")
+                    .font(.system(size: 13))
+                Text("Pinned items are kept")
+                    .font(.system(size: 11))
+                    .foregroundColor(.secondary)
+            }
+            Spacer(minLength: 8)
+            Picker("", selection: $shelf.retentionDays) {
+                ForEach(ShelfRetentionOption.allCases) { option in
+                    Text(option.title).tag(option.rawValue)
+                }
+            }
+            .pickerStyle(.menu)
+            .labelsHidden()
+            .frame(width: 120)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 11)
     }
 }

--- a/docs/SHELF.md
+++ b/docs/SHELF.md
@@ -1,0 +1,19 @@
+# File Shelf
+
+The Shelf module is a local staging area for items users want to keep close to the island temporarily.
+
+## Supported Items
+
+- Files and folders are stored as metadata with security-scoped bookmarks where available.
+- URLs and text snippets are stored as local metadata.
+- Dropped image data is saved locally for shelf use; large file drops are not copied into app storage.
+
+## Actions
+
+Shelf items can be opened, pinned, removed, dragged back out, revealed in Finder, previewed with Quick Look, copied, shared with the system sharing picker, or sent with AirDrop when the sharing service is available.
+
+Pinned items stay ahead of unpinned items and are not removed by retention cleanup.
+
+## Retention
+
+Settings -> Modules -> Shelf retention controls automatic cleanup for unpinned shelf items. The default is Never, which preserves the previous behavior. Missing local files remain visible with a missing state so users can remove the stale entry or copy the stored path.


### PR DESCRIPTION
## Summary
- Completes the first-party Shelf module for staging local files, folders, URLs, text snippets, and images.
- Adds pinning, retention cleanup for unpinned items, missing-file state, image data drops, Quick Look, copy-path, drag-out, AirDrop, and system sharing actions.
- Adds a lightweight full-shelf search/filter and Shelf retention setting.
- Documents the Shelf behavior and keeps all data local by default.

## Scope check
- No issue number is linked to this roadmap item.
- Verified the work fits the existing Shelf module, AppState presentation hooks, module settings, compact/expanded/full-expanded views, and local-first roadmap.
- No cloud upload or clipboard history behavior was added.

## Validation
- `git diff --check`
- Direct Swift typecheck passed with existing project warnings.
- `xcodebuild -version` passed with Xcode 26.5, build 17F42.
- `xcodegen generate` could not run because `xcodegen` is not installed in this environment.

## Manual testing recommended
- Drag in a file, folder, URL, text snippet, and image.
- Relaunch and confirm shelf persistence.
- Pin/unpin, clear unpinned, clear all, and retention cleanup behavior.
- Quick Look, Show in Finder, copy item, copy path, system sharing, AirDrop, and drag-out.
- Delete or move a staged file and confirm the missing state is shown.

## Risk notes
- Dropped image data is persisted locally with a size cap; file and folder drops continue to store metadata/bookmarks instead of copying files.
- Retention defaults to Never to preserve current behavior.
- Quick Look and sharing use public macOS APIs and may depend on the current frontmost app/window for presentation anchoring.